### PR TITLE
fix(dsl): don't consume a parameter index for IS NULL inside an OR

### DIFF
--- a/src/main/kotlin/org/drivine/query/dsl/CypherGenerator.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/CypherGenerator.kt
@@ -715,6 +715,12 @@ object CypherGenerator {
                     val alias = subCondition.propertyPath.substringBefore(".")
                     val baseAlias = if (alias.contains("_")) alias.substringBefore("_") else alias
 
+                    // IS NULL / IS NOT NULL render no $param, so they must not consume a parameter
+                    // index here — the same rule buildWhereClause and extractBindings already apply.
+                    // Incrementing for them desyncs the rendered Cypher from the extracted bindings.
+                    val consumesParam = subCondition.operator != ComparisonOperator.IS_NULL &&
+                        subCondition.operator != ComparisonOperator.IS_NOT_NULL
+
                     if (baseAlias in relationshipNames) {
                         // Convert to RelationshipCondition on the fly
                         val relCondition = WhereCondition.RelationshipCondition(
@@ -722,11 +728,11 @@ object CypherGenerator {
                             targetConditions = listOf(subCondition)
                         )
                         val result = buildRelationshipCondition(relCondition, viewModel, paramIndex, grammar, ecCounter, prologs, bridgeVars, projectedCollectionMode)
-                        paramIndex++
+                        if (consumesParam) paramIndex++
                         result
                     } else {
                         val result = buildPropertyCondition(subCondition, paramIndex)
-                        paramIndex++
+                        if (consumesParam) paramIndex++
                         result
                     }
                 }
@@ -768,7 +774,11 @@ object CypherGenerator {
     private fun countParameters(conditions: List<WhereCondition>): Int {
         return conditions.sumOf { condition ->
             when (condition) {
-                is WhereCondition.PropertyCondition -> 1
+                is WhereCondition.PropertyCondition ->
+                    // IS NULL / IS NOT NULL bind no value, so they add no parameter to the OR's span.
+                    if (condition.operator == ComparisonOperator.IS_NULL ||
+                        condition.operator == ComparisonOperator.IS_NOT_NULL
+                    ) 0 else 1
                 is WhereCondition.RelationshipCondition -> condition.targetConditions.size
                 is WhereCondition.LabelCondition -> 0  // Label conditions don't have parameters
                 is WhereCondition.OrCondition -> countParameters(condition.conditions)

--- a/src/test/kotlin/org/drivine/query/dsl/ContextParametersSyntaxTest.kt
+++ b/src/test/kotlin/org/drivine/query/dsl/ContextParametersSyntaxTest.kt
@@ -2,6 +2,7 @@ package org.drivine.query.dsl
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Tests for context parameters syntax - the cleanest DSL syntax powered by Kotlin 2.2+
@@ -185,6 +186,58 @@ class ContextParametersSyntaxTest {
 
         assertEquals(2, spec.conditions.size)
         assertEquals(1, spec.orders.size)
+    }
+
+    @Test
+    fun `anyOf mixing IS NULL with a comparison keeps Cypher params and bindings aligned`() {
+        val spec = GraphQuerySpec(TestQuery())
+
+        spec.where {
+            anyOf {
+                query.status.isNull()
+                query.age gte 18
+            }
+            query.name eq "Alice" // a value-bearing predicate after the OR
+        }
+
+        val where = CypherGenerator.buildWhereClause(spec.conditions).whereClause!!
+        val bindings = CypherGenerator.extractBindings(spec.conditions)
+
+        // Every $param referenced in the rendered WHERE must have a value in the bindings map.
+        // The IS NULL branch renders no $param, so it must not consume a parameter index. Before the
+        // fix it did: `age` rendered as $param_test_age_2 while its value was bound at param_test_age_1,
+        // and the trailing `name` predicate was shifted too — Neo4j then rejected the query with
+        // "Expected parameter(s): ...".
+        val referenced = Regex("""\$(param_\w+)""").findAll(where).map { it.groupValues[1] }.toSet()
+        assertTrue(referenced.isNotEmpty(), "expected parameters in: $where")
+        referenced.forEach { name ->
+            assertTrue(bindings.containsKey(name), "param \$$name referenced in `$where` but absent from bindings $bindings")
+        }
+        // IS NULL binds nothing; only the two comparisons (age, name) contribute parameters.
+        assertEquals(2, bindings.size, bindings.toString())
+    }
+
+    @Test
+    fun `IS NULL inside anyOf contributes no parameter to a following OR predicate`() {
+        val spec = GraphQuerySpec(TestQuery())
+
+        // Two value-bearing predicates straddling an IS NULL, all inside one OR.
+        spec.where {
+            anyOf {
+                query.age gt 16
+                query.status.isNull()
+                query.age lt 99
+            }
+        }
+
+        val where = CypherGenerator.buildWhereClause(spec.conditions).whereClause!!
+        val bindings = CypherGenerator.extractBindings(spec.conditions)
+
+        val referenced = Regex("""\$(param_\w+)""").findAll(where).map { it.groupValues[1] }.toSet()
+        referenced.forEach { name ->
+            assertTrue(bindings.containsKey(name), "param \$$name referenced in `$where` but absent from bindings $bindings")
+        }
+        assertEquals(2, bindings.size, bindings.toString())
     }
 
     // Test helper classes


### PR DESCRIPTION
Fixes #3.

## Problem

A WHERE built as `anyOf { prop.isNull(); prop gte x }` renders Cypher that references a parameter the bindings map never contains, so Neo4j rejects the query:

```
Expected parameter(s): param_<path>_<n>
```

`IS NULL` / `IS NOT NULL` branches **inside an `OR`** consume a parameter index even though they render no `$param`, while `extractBindings` correctly skips them — so the rendered `$param_<path>_<n>` suffixes drift out of sync with the bindings-map keys.

```kotlin
spec.where {
    anyOf {
        query.status.isNull()
        query.age gte 18
    }
}
// WHERE:    (test.status IS NULL OR test.age >= $param_test_age_1)
// bindings: { param_test_age_0 = 18 }   ← Neo4j: Expected parameter(s): param_test_age_1
```

## Fix (`CypherGenerator`)

Two spots indexed an `IS NULL` branch as if it bound a value; both now treat `IS NULL` / `IS NOT NULL` as binding nothing, matching the rest of the generator and the binding extractor:

- **`buildOrCondition`** — only `paramIndex++` for a value-bearing operator. `buildWhereClause` and `buildPropertyConditionWithLhs` already guard this the same way; the OR branch was the lone exception, so a comparison after an `IS NULL` in the same `OR` rendered `$param_…_(n+1)` while its value was bound at `_n`.
- **`countParameters`** — an `IS NULL` `PropertyCondition` contributes `0`, not `1`, so the running index after an `OR` no longer over-counts and shift predicates that follow the `OR`.

## Test plan

- [x] New regression tests in `ContextParametersSyntaxTest` assert every `$param` rendered in the WHERE has a matching key in `extractBindings` — for an `IS NULL`+comparison `OR`, and for a value-bearing predicate that follows an `IS NULL` within the same `OR`.
- [x] Both tests fail on `main` (reproduce the bug) and pass with this change.
- [x] Full root `:test` suite green (`./gradlew :test`).

Found against `0.0.57`; confirmed on `main`.