### PR TITLE
feat(query): add first-class keyset pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ graphObjectManager.loadAll<PropositionView> {
 }
 ```
 
-For large or changing result sets, prefer keyset pagination with `seekAfter`. Its properties must
+For large or changing result sets, prefer keyset pagination with `seek`. Its properties must
 match the root `orderBy` properties in the same order; Drivine derives each comparison from the
 sort direction and builds the lexicographic continuation predicate. End with a unique key so ties
 cannot be skipped or duplicated:
@@ -840,18 +840,29 @@ graphObjectManager.loadAll<SessionView> {
         session.lastActivityAt.desc()
         session.sessionId.desc()
     }
-    seekAfter {
+    seek {
         session.lastActivityAt after cursor.lastActivityAt
         session.sessionId after cursor.sessionId
     }
-    limit(pageSize + 1)
+    limit(pageSize)
 }
 ```
 
-`seekAfter` rejects missing/misaligned order keys, null cursor values, and use together with `skip`.
-Drivine intentionally owns query planning but not cursor serialization; applications can expose an
-opaque cursor format appropriate to their API. Java callers use `.seekAfter(q -> List.of(...))` and
-the Java-friendly `PropertyReference.after(value)` method.
+Each cursor value is the corresponding property of the last row of the previous page. To tell the caller whether a next page exists
+without a second query, ask for `limit(pageSize + 1)`, return the first `pageSize` results, and treat
+the presence of the extra row as `hasMore`.
+
+**The ordered properties must be non-null in the data.** A row whose sort key is null satisfies no
+comparison, so it is dropped from every page after the first — and engines disagree about where
+nulls sort, so the shape of that loss is not even portable. Use non-null properties as keys, or
+filter nulls out in `where`.
+
+`seek` rejects missing/misaligned order keys, null cursor values, use together with `skip`, and
+use on any operation that would ignore it (`count`, `deleteAll`, `loadNearest`, `loadMatching`) —
+those fail loudly rather than quietly returning an unpaginated result. Drivine intentionally owns
+query planning but not cursor serialization; applications can expose an opaque cursor format
+appropriate to their API. Java callers use `.seek(q -> List.of(...))` and the Java-friendly
+`PropertyReference.after(value)` method.
 
 For a `@GraphView`, `limit(n)` bounds **root entities** — each returned view keeps its relationships
 fully populated (relationships are pattern comprehensions, so one root is one row). Pair `limit` with

--- a/README.md
+++ b/README.md
@@ -829,6 +829,30 @@ graphObjectManager.loadAll<PropositionView> {
 }
 ```
 
+For large or changing result sets, prefer keyset pagination with `seekAfter`. Its properties must
+match the root `orderBy` properties in the same order; Drivine derives each comparison from the
+sort direction and builds the lexicographic continuation predicate. End with a unique key so ties
+cannot be skipped or duplicated:
+
+```kotlin
+graphObjectManager.loadAll<SessionView> {
+    orderBy {
+        session.lastActivityAt.desc()
+        session.sessionId.desc()
+    }
+    seekAfter {
+        session.lastActivityAt after cursor.lastActivityAt
+        session.sessionId after cursor.sessionId
+    }
+    limit(pageSize + 1)
+}
+```
+
+`seekAfter` rejects missing/misaligned order keys, null cursor values, and use together with `skip`.
+Drivine intentionally owns query planning but not cursor serialization; applications can expose an
+opaque cursor format appropriate to their API. Java callers use `.seekAfter(q -> List.of(...))` and
+the Java-friendly `PropertyReference.after(value)` method.
+
 For a `@GraphView`, `limit(n)` bounds **root entities** — each returned view keeps its relationships
 fully populated (relationships are pattern comprehensions, so one root is one row). Pair `limit` with
 `orderBy` for a deterministic top-N; without ordering the subset is an arbitrary `≤ n`. `count(…)`

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.drivine'
-version = '0.0.73'
+version = '0.0.74-SNAPSHOT'
 
 base {
 	archivesName = 'drivine4j'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.drivine'
-version = '0.0.74-SNAPSHOT'
+version = '0.0.74'
 
 base {
 	archivesName = 'drivine4j'

--- a/drivine4j-codegen/src/main/kotlin/org/drivine/codegen/QueryDslGenerator.kt
+++ b/drivine4j-codegen/src/main/kotlin/org/drivine/codegen/QueryDslGenerator.kt
@@ -1180,7 +1180,7 @@ class QueryDslGenerator(
      * where { core.guideProgress gte 0 }
      * ```
      *
-     * Generates extensions for both WhereBuilder and OrderBuilder contexts.
+     * Generates extensions for WhereBuilder, OrderBuilder, and SeekBuilder contexts.
      */
     private fun generateContextPropertyExtensionsCode(
         graphViewClass: KSClassDeclaration,
@@ -1215,6 +1215,15 @@ public val ${viewProp.name}: $fullyQualifiedPropertiesClassName
             // Generate context property for OrderBuilder
             code.appendLine("""
 context(builder: org.drivine.query.dsl.OrderBuilder<$dslClassName>)
+@Suppress("CONTEXT_RECEIVERS_DEPRECATED")
+public val ${viewProp.name}: $fullyQualifiedPropertiesClassName
+    get() = builder.queryObject.${viewProp.name}
+""".trimIndent())
+            code.appendLine()
+
+            // Generate context property for SeekBuilder
+            code.appendLine("""
+context(builder: org.drivine.query.dsl.SeekBuilder<$dslClassName>)
 @Suppress("CONTEXT_RECEIVERS_DEPRECATED")
 public val ${viewProp.name}: $fullyQualifiedPropertiesClassName
     get() = builder.queryObject.${viewProp.name}

--- a/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
+++ b/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
@@ -18,6 +18,7 @@ import org.drivine.query.VectorSearchPlanner
 import org.drivine.query.dsl.CypherGenerator
 import org.drivine.query.dsl.GraphQuerySpec
 import org.drivine.query.dsl.OrderClauseResult
+import org.drivine.query.dsl.KeysetPlanner
 import org.drivine.session.SessionManager
 
 /**
@@ -311,16 +312,29 @@ class GraphObjectManager(
             OrderClauseResult(null, emptyList())
         }
 
-        val baseQuery = if (querySpec.depthOverrides.isNotEmpty() && builder is GraphViewQueryBuilder) {
-            builder.buildQuery(ctx.whereClause, orderResult.orderByClause, orderResult.collectionSorts, querySpec.depthOverrides, ctx.prologs, ctx.bridgeVariables)
+        require(querySpec.seekValues.isEmpty() || querySpec.skip == null) {
+            "seekAfter and skip cannot be used together"
+        }
+        val keysetPlan = if (querySpec.seekValues.isNotEmpty()) {
+            KeysetPlanner.plan(orderResult.rootOrders, querySpec.seekValues)
         } else {
-            builder.buildQuery(ctx.whereClause, orderResult.orderByClause, orderResult.collectionSorts, ctx.prologs, ctx.bridgeVariables)
+            null
+        }
+        val effectiveWhereClause = listOfNotNull(ctx.whereClause, keysetPlan?.predicate)
+            .joinToString(" AND ") { "($it)" }
+            .takeIf { it.isNotEmpty() }
+        val effectiveBindings = ctx.bindings + (keysetPlan?.bindings ?: emptyMap())
+
+        val baseQuery = if (querySpec.depthOverrides.isNotEmpty() && builder is GraphViewQueryBuilder) {
+            builder.buildQuery(effectiveWhereClause, orderResult.orderByClause, orderResult.collectionSorts, querySpec.depthOverrides, ctx.prologs, ctx.bridgeVariables)
+        } else {
+            builder.buildQuery(effectiveWhereClause, orderResult.orderByClause, orderResult.collectionSorts, ctx.prologs, ctx.bridgeVariables)
         }
 
         // SKIP/LIMIT are the final clauses, after RETURN … ORDER BY …. For a @GraphView each root is
         // one row (relationships are pattern comprehensions in the projection), so LIMIT bounds root
         // entities and keeps their collections intact.
-        val (query, bindings) = applyPagination(baseQuery, ctx.bindings, querySpec.skip, querySpec.limit)
+        val (query, bindings) = applyPagination(baseQuery, effectiveBindings, querySpec.skip, querySpec.limit)
 
         val results = persistenceManager.query(
             QuerySpecification

--- a/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
+++ b/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
@@ -302,7 +302,7 @@ class GraphObjectManager(
         querySpec.spec()
 
         val builder = GraphObjectQueryBuilder.forClass(graphClass, grammar)
-        val ctx = buildQueryContext(graphClass, querySpec)
+        val ctx = buildQueryContext(graphClass, querySpec, supportsSeek = true)
 
         // Process ORDER BY clause - separate root orders from collection sorts
         val relationshipNames = ctx.viewModel?.relationships?.map { it.fieldName }?.toSet() ?: emptySet()
@@ -313,16 +313,21 @@ class GraphObjectManager(
         }
 
         require(querySpec.seekValues.isEmpty() || querySpec.skip == null) {
-            "seekAfter and skip cannot be used together"
+            "seek and skip cannot be used together"
         }
         val keysetPlan = if (querySpec.seekValues.isNotEmpty()) {
-            KeysetPlanner.plan(orderResult.rootOrders, querySpec.seekValues)
+            KeysetPlanner.plan(orderResult.rootOrders, querySpec.seekValues, orderResult.collectionSorts.size)
         } else {
             null
         }
         val effectiveWhereClause = listOfNotNull(ctx.whereClause, keysetPlan?.predicate)
             .joinToString(" AND ") { "($it)" }
             .takeIf { it.isNotEmpty() }
+        keysetPlan?.bindings?.keys?.forEach { reserved ->
+            require(reserved !in ctx.bindings) {
+                "Keyset cursor parameter \$$reserved collides with a where-clause binding"
+            }
+        }
         val effectiveBindings = ctx.bindings + (keysetPlan?.bindings ?: emptyMap())
 
         val baseQuery = if (querySpec.depthOverrides.isNotEmpty() && builder is GraphViewQueryBuilder) {
@@ -597,11 +602,20 @@ class GraphObjectManager(
 
     /**
      * Builds query context from a GraphQuerySpec, extracting the view model, WHERE clause, and bindings.
+     *
+     * @param supportsSeek whether the calling operation applies [GraphQuerySpec.seek]. Only
+     *   `loadAll` does; every other path would silently ignore the cursor and return (or delete, or
+     *   count) the whole unpaginated result, so they reject it here instead.
      */
     private fun <Q : Any> buildQueryContext(
         graphClass: Class<*>,
-        querySpec: GraphQuerySpec<Q>
+        querySpec: GraphQuerySpec<Q>,
+        supportsSeek: Boolean = false,
     ): QueryContext {
+        require(supportsSeek || querySpec.seekValues.isEmpty()) {
+            "seek is only supported by loadAll; this operation would ignore the cursor"
+        }
+
         val viewModel = if (graphClass.isAnnotationPresent(GraphView::class.java)) {
             GraphViewModel.from(graphClass)
         } else {

--- a/src/main/kotlin/org/drivine/query/dsl/CypherGenerator.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/CypherGenerator.kt
@@ -287,7 +287,7 @@ object CypherGenerator {
             null
         }
 
-        return OrderClauseResult(orderByClause, collectionSorts)
+        return OrderClauseResult(orderByClause, collectionSorts, rootOrders)
     }
 
     /**
@@ -935,7 +935,7 @@ object CypherGenerator {
      * Converts a value to a Neo4j-compatible type.
      * Neo4j driver doesn't support java.util.UUID natively, so we convert it to String.
      */
-    private fun convertToNeo4jValue(value: Any?): Any? {
+    internal fun convertToNeo4jValue(value: Any?): Any? {
         return when (value) {
             is java.util.UUID -> value.toString()
             is Collection<*> -> value.map { convertToNeo4jValue(it) }

--- a/src/main/kotlin/org/drivine/query/dsl/GraphQueryDsl.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/GraphQueryDsl.kt
@@ -33,6 +33,7 @@ package org.drivine.query.dsl
 class GraphQuerySpec<T : Any>(private val queryObject: T) {
     internal val conditions = mutableListOf<WhereCondition>()
     internal val orders = mutableListOf<OrderSpec>()
+    internal val seekValues = mutableListOf<SeekValueSpec>()
     internal val depthOverrides = mutableMapOf<String, Int>()
     internal var limit: Int? = null
     internal var skip: Int? = null
@@ -62,6 +63,44 @@ class GraphQuerySpec<T : Any>(private val queryObject: T) {
     fun skip(n: Int) {
         require(n >= 0) { "skip must be >= 0, was $n" }
         skip = n
+    }
+
+    /**
+     * Continues a deterministically ordered query after a keyset cursor.
+     *
+     * Each property in this block must correspond, in the same order, to a root property declared
+     * in [orderBy]. Drivine derives the comparison operator from that property's direction (`<` for
+     * `DESC`, `>` for `ASC`) and expands compound cursors into the correct lexicographic predicate.
+     * Cursor values must be non-null. Pair the final key with a unique property (normally the root
+     * `@NodeId`) so every result has a unique position.
+     *
+     * ```kotlin
+     * orderBy {
+     *     session.lastActivityAt.desc()
+     *     session.sessionId.desc()
+     * }
+     * seekAfter {
+     *     session.lastActivityAt after cursor.lastActivityAt
+     *     session.sessionId after cursor.sessionId
+     * }
+     * limit(21)
+     * ```
+     *
+     * [seekAfter] and [skip] are mutually exclusive.
+     */
+    fun seekAfter(block: context(SeekBuilder<T>) () -> Unit) {
+        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
+        val builder = SeekBuilder(queryObject)
+        block(builder)
+        require(builder.values.isNotEmpty()) { "seekAfter requires at least one cursor value" }
+        seekValues.addAll(builder.values)
+    }
+
+    /** Explicit form of [seekAfter], also useful from Kotlin versions with context overload ambiguity. */
+    fun seekAfter(vararg values: SeekValueSpec) {
+        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
+        require(values.isNotEmpty()) { "seekAfter requires at least one cursor value" }
+        seekValues.addAll(values)
     }
 
     /**
@@ -116,6 +155,11 @@ class GraphQuerySpec<T : Any>(private val queryObject: T) {
         val builder = OrderBuilder(queryObject)
         block(builder)
         orders.addAll(builder.orders)
+    }
+
+    /** Explicit form of [orderBy] for callers that already have typed [OrderSpec] values. */
+    fun orderBy(vararg specifications: OrderSpec) {
+        orders.addAll(specifications)
     }
 }
 
@@ -327,10 +371,34 @@ class OrderBuilder<T : Any>(
     }
 }
 
+/** Collects the typed property values that make up a keyset cursor. */
+class SeekBuilder<T : Any>(
+    /** The generated query DSL object providing property references. */
+    val queryObject: T,
+) {
+    internal val values = mutableListOf<SeekValueSpec>()
+
+    /** Adds a cursor value explicitly; useful when overload resolution needs an expected type. */
+    operator fun invoke(value: SeekValueSpec) {
+        values.add(value)
+    }
+}
+
+/** A property path and its value at the end of the previous page. */
+data class SeekValueSpec(
+    val propertyPath: String,
+    val value: Any,
+)
+
 /**
  * Context-aware property to access the query object within an orderBy block.
  */
 context(builder: OrderBuilder<T>)
+val <T : Any> query: T
+    get() = builder.queryObject
+
+/** Context-aware access to the generated query object within a [GraphQuerySpec.seekAfter] block. */
+context(builder: SeekBuilder<T>)
 val <T : Any> query: T
     get() = builder.queryObject
 
@@ -492,5 +560,7 @@ data class CollectionSortSpec(
  */
 data class OrderClauseResult(
     val orderByClause: String?,
-    val collectionSorts: List<CollectionSortSpec>
+    val collectionSorts: List<CollectionSortSpec>,
+    /** Root-entity orders, retained for keyset planning after collection sorts are separated. */
+    val rootOrders: List<OrderSpec> = emptyList(),
 )

--- a/src/main/kotlin/org/drivine/query/dsl/GraphQueryDsl.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/GraphQueryDsl.kt
@@ -71,36 +71,33 @@ class GraphQuerySpec<T : Any>(private val queryObject: T) {
      * Each property in this block must correspond, in the same order, to a root property declared
      * in [orderBy]. Drivine derives the comparison operator from that property's direction (`<` for
      * `DESC`, `>` for `ASC`) and expands compound cursors into the correct lexicographic predicate.
-     * Cursor values must be non-null. Pair the final key with a unique property (normally the root
-     * `@NodeId`) so every result has a unique position.
+     * Cursor values must be non-null, and so must the ordered properties themselves: a row whose
+     * key is null satisfies no comparison and would be skipped by every page after the first. Pair
+     * the final key with a unique property (normally the root `@NodeId`) so every result has a
+     * unique position.
      *
      * ```kotlin
      * orderBy {
      *     session.lastActivityAt.desc()
      *     session.sessionId.desc()
      * }
-     * seekAfter {
+     * seek {
      *     session.lastActivityAt after cursor.lastActivityAt
      *     session.sessionId after cursor.sessionId
      * }
-     * limit(21)
+     * limit(pageSize)
      * ```
      *
-     * [seekAfter] and [skip] are mutually exclusive.
+     * [seek] and [skip] are mutually exclusive, and [seek] is only supported on the
+     * `loadAll` family — a scored search or a `count`/`deleteAll` rejects it rather than silently
+     * returning an unpaginated result.
      */
-    fun seekAfter(block: context(SeekBuilder<T>) () -> Unit) {
-        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
+    fun seek(block: context(SeekBuilder<T>) () -> Unit) {
+        check(seekValues.isEmpty()) { "seek may only be specified once" }
         val builder = SeekBuilder(queryObject)
         block(builder)
-        require(builder.values.isNotEmpty()) { "seekAfter requires at least one cursor value" }
+        require(builder.values.isNotEmpty()) { "seek requires at least one cursor value" }
         seekValues.addAll(builder.values)
-    }
-
-    /** Explicit form of [seekAfter], also useful from Kotlin versions with context overload ambiguity. */
-    fun seekAfter(vararg values: SeekValueSpec) {
-        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
-        require(values.isNotEmpty()) { "seekAfter requires at least one cursor value" }
-        seekValues.addAll(values)
     }
 
     /**
@@ -155,11 +152,6 @@ class GraphQuerySpec<T : Any>(private val queryObject: T) {
         val builder = OrderBuilder(queryObject)
         block(builder)
         orders.addAll(builder.orders)
-    }
-
-    /** Explicit form of [orderBy] for callers that already have typed [OrderSpec] values. */
-    fun orderBy(vararg specifications: OrderSpec) {
-        orders.addAll(specifications)
     }
 }
 
@@ -377,14 +369,15 @@ class SeekBuilder<T : Any>(
     val queryObject: T,
 ) {
     internal val values = mutableListOf<SeekValueSpec>()
-
-    /** Adds a cursor value explicitly; useful when overload resolution needs an expected type. */
-    operator fun invoke(value: SeekValueSpec) {
-        values.add(value)
-    }
 }
 
-/** A property path and its value at the end of the previous page. */
+/**
+ * A property path and its value at the end of the previous page.
+ *
+ * Obtain these through the typed property references — `property after value` inside a
+ * [GraphQuerySpec.seek] block, or `property.after(value)` from Java — rather than
+ * constructing them directly: [propertyPath] is interpolated into Cypher verbatim.
+ */
 data class SeekValueSpec(
     val propertyPath: String,
     val value: Any,
@@ -397,7 +390,7 @@ context(builder: OrderBuilder<T>)
 val <T : Any> query: T
     get() = builder.queryObject
 
-/** Context-aware access to the generated query object within a [GraphQuerySpec.seekAfter] block. */
+/** Context-aware access to the generated query object within a [GraphQuerySpec.seek] block. */
 context(builder: SeekBuilder<T>)
 val <T : Any> query: T
     get() = builder.queryObject

--- a/src/main/kotlin/org/drivine/query/dsl/JavaQueryBuilder.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/JavaQueryBuilder.kt
@@ -106,6 +106,7 @@ class JavaQueryBuilder<T : Any, Q : Any>(
 ) {
     private val conditions = mutableListOf<WhereCondition>()
     private val orders = mutableListOf<OrderSpec>()
+    private val seekValues = mutableListOf<SeekValueSpec>()
     private var limit: Int? = null
     private var skip: Int? = null
 
@@ -183,6 +184,18 @@ class JavaQueryBuilder<T : Any, Q : Any>(
     }
 
     /**
+     * Continues after a compound keyset cursor. Values must match the root [orderBy] properties in
+     * the same order; each value is type-checked by `PropertyReference.after(value)`.
+     */
+    fun seekAfter(values: java.util.function.Function<Q, List<SeekValueSpec>>): JavaQueryBuilder<T, Q> {
+        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
+        val supplied = values.apply(queryDsl)
+        require(supplied.isNotEmpty()) { "seekAfter requires at least one cursor value" }
+        seekValues.addAll(supplied)
+        return this
+    }
+
+    /**
      * Limits the result to at most [n] entities (for a `@GraphView`, [n] roots). Pair with [orderBy]
      * for a deterministic top-N.
      */
@@ -207,6 +220,7 @@ class JavaQueryBuilder<T : Any, Q : Any>(
             // Transfer collected conditions and orders to the GraphQuerySpec
             this.conditions.addAll(this@JavaQueryBuilder.conditions)
             this.orders.addAll(this@JavaQueryBuilder.orders)
+            this.seekValues.addAll(this@JavaQueryBuilder.seekValues)
             this@JavaQueryBuilder.limit?.let { limit(it) }
             this@JavaQueryBuilder.skip?.let { skip(it) }
         }

--- a/src/main/kotlin/org/drivine/query/dsl/JavaQueryBuilder.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/JavaQueryBuilder.kt
@@ -187,10 +187,10 @@ class JavaQueryBuilder<T : Any, Q : Any>(
      * Continues after a compound keyset cursor. Values must match the root [orderBy] properties in
      * the same order; each value is type-checked by `PropertyReference.after(value)`.
      */
-    fun seekAfter(values: java.util.function.Function<Q, List<SeekValueSpec>>): JavaQueryBuilder<T, Q> {
-        check(seekValues.isEmpty()) { "seekAfter may only be specified once" }
+    fun seek(values: java.util.function.Function<Q, List<SeekValueSpec>>): JavaQueryBuilder<T, Q> {
+        check(seekValues.isEmpty()) { "seek may only be specified once" }
         val supplied = values.apply(queryDsl)
-        require(supplied.isNotEmpty()) { "seekAfter requires at least one cursor value" }
+        require(supplied.isNotEmpty()) { "seek requires at least one cursor value" }
         seekValues.addAll(supplied)
         return this
     }

--- a/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
@@ -19,19 +19,42 @@ internal data class KeysetPlan(
  * Compiles root ordering plus cursor values into a lexicographic seek predicate.
  *
  * For `a DESC, b DESC` after `(A, B)` this emits:
- * `(a < $_seek_0 OR (a = $_seek_0 AND b < $_seek_1))`.
+ * `(a <= $_seek_0 AND (a < $_seek_0 OR (a = $_seek_0 AND b < $_seek_1)))`.
+ *
+ * The leading `a <= $_seek_0` is logically redundant — the disjunction already implies it — but a
+ * top-level `OR` typically stops a planner from using an index on `a`, whereas the extra conjunct
+ * gives it a range bound to seek on. It is omitted for a single-key cursor, where the predicate is
+ * already a bare comparison.
+ *
+ * **Nulls.** A row whose ordered property is null never satisfies a comparison, so it is dropped by
+ * every page after the first. Engines also disagree on where nulls sort. Keyset properties must be
+ * non-null in the data; see the README's pagination section.
  */
 internal object KeysetPlanner {
 
-    fun plan(orders: List<OrderSpec>, values: List<SeekValueSpec>): KeysetPlan {
-        require(orders.isNotEmpty()) { "seekAfter requires at least one root orderBy property" }
+    /**
+     * @param orders the root-level orders, in declaration order
+     * @param values the cursor components, which must align 1:1 with [orders]
+     * @param collectionSortCount how many declared orders were routed to collection sorts rather
+     *   than root ordering — used only to explain an arity mismatch
+     */
+    fun plan(
+        orders: List<OrderSpec>,
+        values: List<SeekValueSpec>,
+        collectionSortCount: Int = 0,
+    ): KeysetPlan {
+        require(orders.isNotEmpty()) {
+            "seek requires at least one root orderBy property" +
+                collectionSortHint(collectionSortCount)
+        }
         require(orders.size == values.size) {
-            "seekAfter supplied ${values.size} cursor values for ${orders.size} root orderBy properties"
+            "seek supplied ${values.size} cursor values for ${orders.size} root orderBy " +
+                "properties" + collectionSortHint(collectionSortCount)
         }
 
         orders.zip(values).forEachIndexed { index, (order, value) ->
             require(order.propertyPath == value.propertyPath) {
-                "seekAfter property #${index + 1} is ${value.propertyPath}, but orderBy property " +
+                "seek property #${index + 1} is ${value.propertyPath}, but orderBy property " +
                     "#${index + 1} is ${order.propertyPath}"
             }
         }
@@ -40,20 +63,42 @@ internal object KeysetPlanner {
             val equalPrefix = (0 until branchIndex).map { keyIndex ->
                 "${orders[keyIndex].propertyPath} = \$${paramName(keyIndex)}"
             }
-            val comparison = when (orders[branchIndex].direction) {
-                OrderDirection.ASC -> ">"
-                OrderDirection.DESC -> "<"
-            }
-            val tail = "${orders[branchIndex].propertyPath} $comparison \$${paramName(branchIndex)}"
+            val tail = comparison(orders[branchIndex], strict = true, index = branchIndex)
             (equalPrefix + tail).joinToString(" AND ").let { if (branchIndex == 0) it else "($it)" }
         }
 
+        val disjunction = branches.joinToString(" OR ", prefix = "(", postfix = ")")
+        val predicate = if (orders.size == 1) {
+            disjunction
+        } else {
+            "(${comparison(orders[0], strict = false, index = 0)} AND $disjunction)"
+        }
+
         return KeysetPlan(
-            predicate = branches.joinToString(" OR ", prefix = "(", postfix = ")"),
+            predicate = predicate,
             bindings = values.mapIndexed { index, value ->
-                paramName(index) to requireNotNull(CypherGenerator.convertToNeo4jValue(value.value))
+                paramName(index) to requireNotNull(CypherGenerator.convertToNeo4jValue(value.value)) {
+                    "Keyset cursor value for ${value.propertyPath} converted to null"
+                }
             }.toMap(),
         )
+    }
+
+    /** Renders `path < $_seek_n` (strict) or `path <= $_seek_n`, per the order's direction. */
+    private fun comparison(order: OrderSpec, strict: Boolean, index: Int): String {
+        val operator = when (order.direction) {
+            OrderDirection.ASC -> if (strict) ">" else ">="
+            OrderDirection.DESC -> if (strict) "<" else "<="
+        }
+        return "${order.propertyPath} $operator \$${paramName(index)}"
+    }
+
+    private fun collectionSortHint(collectionSortCount: Int): String = when (collectionSortCount) {
+        0 -> ""
+        1 -> " (1 declared orderBy property sorts a relationship collection, which cannot " +
+            "participate in a keyset cursor)"
+        else -> " ($collectionSortCount declared orderBy properties sort a relationship " +
+            "collection, which cannot participate in a keyset cursor)"
     }
 
     private fun paramName(index: Int): String = "_seek_$index"

--- a/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.drivine.query.dsl
+
+/** A keyset continuation predicate and its reserved parameter bindings. */
+internal data class KeysetPlan(
+    val predicate: String,
+    val bindings: Map<String, Any>,
+)
+
+/**
+ * Compiles root ordering plus cursor values into a lexicographic seek predicate.
+ *
+ * For `a DESC, b DESC` after `(A, B)` this emits:
+ * `(a < $_seek_0 OR (a = $_seek_0 AND b < $_seek_1))`.
+ */
+internal object KeysetPlanner {
+
+    fun plan(orders: List<OrderSpec>, values: List<SeekValueSpec>): KeysetPlan {
+        require(orders.isNotEmpty()) { "seekAfter requires at least one root orderBy property" }
+        require(orders.size == values.size) {
+            "seekAfter supplied ${values.size} cursor values for ${orders.size} root orderBy properties"
+        }
+
+        orders.zip(values).forEachIndexed { index, (order, value) ->
+            require(order.propertyPath == value.propertyPath) {
+                "seekAfter property #${index + 1} is ${value.propertyPath}, but orderBy property " +
+                    "#${index + 1} is ${order.propertyPath}"
+            }
+        }
+
+        val branches = orders.indices.map { branchIndex ->
+            val equalPrefix = (0 until branchIndex).map { keyIndex ->
+                "${orders[keyIndex].propertyPath} = \$${paramName(keyIndex)}"
+            }
+            val comparison = when (orders[branchIndex].direction) {
+                OrderDirection.ASC -> ">"
+                OrderDirection.DESC -> "<"
+            }
+            val tail = "${orders[branchIndex].propertyPath} $comparison \$${paramName(branchIndex)}"
+            (equalPrefix + tail).joinToString(" AND ").let { if (branchIndex == 0) it else "($it)" }
+        }
+
+        return KeysetPlan(
+            predicate = branches.joinToString(" OR ", prefix = "(", postfix = ")"),
+            bindings = values.mapIndexed { index, value ->
+                paramName(index) to requireNotNull(CypherGenerator.convertToNeo4jValue(value.value))
+            }.toMap(),
+        )
+    }
+
+    private fun paramName(index: Int): String = "_seek_$index"
+}

--- a/src/main/kotlin/org/drivine/query/dsl/PropertyReference.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/PropertyReference.kt
@@ -289,7 +289,7 @@ open class PropertyReference<T>(
 
     /**
      * Creates a Java-friendly keyset cursor value for this property. Kotlin callers normally use
-     * the context-aware infix form inside `seekAfter { property after value }`.
+     * the context-aware infix form inside `seek { property after value }`.
      */
     fun after(value: T): SeekValueSpec {
         require(value != null) { "Keyset cursor values must be non-null for $alias.$propertyName" }
@@ -422,7 +422,10 @@ open class PropertyReference<T>(
         builder.orders.add(OrderSpec("$alias.$propertyName", OrderDirection.DESC))
     }
 
-    /** Registers this property's non-null value as one component of a keyset cursor. */
+    /**
+     * Registers this property's non-null value as one component of a keyset cursor: reads as
+     * `session.lastActivityAt after cursor.lastActivityAt` — the page starts strictly after it.
+     */
     context(builder: SeekBuilder<*>)
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("afterContext")

--- a/src/main/kotlin/org/drivine/query/dsl/PropertyReference.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/PropertyReference.kt
@@ -287,6 +287,15 @@ open class PropertyReference<T>(
         )
     }
 
+    /**
+     * Creates a Java-friendly keyset cursor value for this property. Kotlin callers normally use
+     * the context-aware infix form inside `seekAfter { property after value }`.
+     */
+    fun after(value: T): SeekValueSpec {
+        require(value != null) { "Keyset cursor values must be non-null for $alias.$propertyName" }
+        return SeekValueSpec("$alias.$propertyName", value)
+    }
+
     // ==================== Kotlin context parameter methods ====================
     // These methods auto-register conditions when used within a where/orderBy block.
     // They have different signatures (take WhereBuilder context, return Unit).
@@ -411,6 +420,15 @@ open class PropertyReference<T>(
     @JvmName("descContext")
     fun desc() {
         builder.orders.add(OrderSpec("$alias.$propertyName", OrderDirection.DESC))
+    }
+
+    /** Registers this property's non-null value as one component of a keyset cursor. */
+    context(builder: SeekBuilder<*>)
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("afterContext")
+    infix fun after(value: T) {
+        require(value != null) { "Keyset cursor values must be non-null for $alias.$propertyName" }
+        builder.values.add(SeekValueSpec("$alias.$propertyName", value))
     }
 
     // Helper to create PropertyCondition

--- a/src/test/java/org/drivine/query/dsl/JavaKeysetApiTest.java
+++ b/src/test/java/org/drivine/query/dsl/JavaKeysetApiTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.drivine.query.dsl;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.drivine.manager.GraphObjectManager;
+import org.junit.jupiter.api.Test;
+
+class JavaKeysetApiTest {
+
+    @Test
+    void compoundSeekIsAvailableFromTheJavaFluentApi() {
+        TestDsl dsl = new TestDsl();
+        JavaQueryBuilder<Object, TestDsl> builder =
+                new JavaQueryBuilder<>(Object.class, dsl, mock(GraphObjectManager.class));
+
+        JavaQueryBuilder<Object, TestDsl> result = builder
+                .orderBy(q -> q.activity.desc())
+                .orderBy(q -> q.id.desc())
+                .seekAfter(q -> List.of(q.activity.after(42L), q.id.after("session-42")))
+                .limit(21);
+
+        assertSame(builder, result);
+    }
+
+    private static final class TestDsl {
+        private final PropertyReference<Long> activity = new PropertyReference<>("session", "lastActivityAt");
+        private final PropertyReference<String> id = new PropertyReference<>("session", "sessionId");
+    }
+}

--- a/src/test/java/org/drivine/query/dsl/JavaKeysetApiTest.java
+++ b/src/test/java/org/drivine/query/dsl/JavaKeysetApiTest.java
@@ -27,7 +27,7 @@ class JavaKeysetApiTest {
         JavaQueryBuilder<Object, TestDsl> result = builder
                 .orderBy(q -> q.activity.desc())
                 .orderBy(q -> q.id.desc())
-                .seekAfter(q -> List.of(q.activity.after(42L), q.id.after("session-42")))
+                .seek(q -> List.of(q.activity.after(42L), q.id.after("session-42")))
                 .limit(21);
 
         assertSame(builder, result);

--- a/src/test/kotlin/org/drivine/manager/LimitSkipCrossEngineTest.kt
+++ b/src/test/kotlin/org/drivine/manager/LimitSkipCrossEngineTest.kt
@@ -54,6 +54,20 @@ private fun verify(gom: GraphObjectManager) {
     assertEquals(listOf("p3", "p2"), page2)
     assertTrue((page1.toSet() intersect page2.toSet()).isEmpty())
 
+    // Equivalent second page via a compound keyset. The id is the deterministic tie-breaker.
+    val keysetPage2 = ids {
+        orderBy {
+            query.proposition.level.desc()
+            query.proposition.id.desc()
+        }
+        seekAfter {
+            query.proposition.level after 4
+            query.proposition.id after "p4"
+        }
+        limit(2)
+    }
+    assertEquals(listOf("p3", "p2"), keysetPage2)
+
     // edge cases
     assertTrue(load { limit(0) }.isEmpty(), "limit(0) -> empty")
     assertTrue(load { skip(100) }.isEmpty(), "skip past the end -> empty")

--- a/src/test/kotlin/org/drivine/manager/LimitSkipCrossEngineTest.kt
+++ b/src/test/kotlin/org/drivine/manager/LimitSkipCrossEngineTest.kt
@@ -7,6 +7,7 @@ import org.drivine.mapper.Neo4jObjectMapper
 import org.drivine.mapper.SubtypeRegistry
 import org.drivine.query.QuerySpecification
 import org.drivine.query.dsl.GraphQuerySpec
+import org.drivine.query.dsl.anyOf
 import org.drivine.query.dsl.query
 import org.drivine.query.grammar.CypherDialect
 import org.drivine.session.SessionManager
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Neo4jContainer
 import org.testcontainers.containers.wait.strategy.Wait
@@ -31,6 +33,10 @@ import kotlin.test.assertTrue
  * **GraphView root-cardinality** decision: `limit(n)` bounds *root entities* (each with its to-many
  * relationship fully populated), not post-expansion rows; that pagination is disjoint; the edge
  * cases; and that `count` ignores `limit`. SKIP/LIMIT are bound as `$_skip`/`$_limit`.
+ *
+ * Also covers `seek` keyset pagination on the same data: that it reproduces the offset page,
+ * composes with an OR'd caller `where` without widening it, walks the whole relation exactly once,
+ * and is rejected where it would otherwise be silently ignored.
  *
  * Data: p1..p5 with level 1..5; each has one mention, p5 has two.
  */
@@ -60,13 +66,73 @@ private fun verify(gom: GraphObjectManager) {
             query.proposition.level.desc()
             query.proposition.id.desc()
         }
-        seekAfter {
+        seek {
             query.proposition.level after 4
             query.proposition.id after "p4"
         }
         limit(2)
     }
     assertEquals(listOf("p3", "p2"), keysetPage2)
+
+    // A keyset composes with a caller `where`, including one whose top level is an OR: the two must
+    // be parenthesised independently, or the seek bound would bind to only the last OR branch.
+    val filteredKeyset = ids {
+        where {
+            anyOf {
+                query.proposition.id eq "p2"
+                query.proposition.id eq "p4"
+                query.proposition.id eq "p5"
+            }
+        }
+        orderBy {
+            query.proposition.level.desc()
+            query.proposition.id.desc()
+        }
+        seek {
+            query.proposition.level after 5
+            query.proposition.id after "p5"
+        }
+        limit(10)
+    }
+    assertEquals(listOf("p4", "p2"), filteredKeyset, "seek must not widen an OR'd where clause")
+
+    // Walking the whole relation by cursor visits every root exactly once, in order.
+    val walked = mutableListOf<String>()
+    var cursor: Pair<Int, String>? = null
+    while (true) {
+        val page = load {
+            orderBy {
+                query.proposition.level.desc()
+                query.proposition.id.desc()
+            }
+            cursor?.let { (level, id) ->
+                seek {
+                    query.proposition.level after level
+                    query.proposition.id after id
+                }
+            }
+            limit(2)
+        }
+        if (page.isEmpty()) break
+        walked += page.map { it.proposition.id }
+        cursor = page.last().let { it.proposition.level to it.proposition.id }
+    }
+    assertEquals(listOf("p5", "p4", "p3", "p2", "p1"), walked)
+
+    // seek is rejected where it would be silently ignored, rather than over-returning.
+    assertThrows<IllegalArgumentException> {
+        ids {
+            orderBy { query.proposition.level.desc() }
+            seek { query.proposition.level after 4 }
+            skip(1)
+        }
+    }
+    assertThrows<IllegalArgumentException> {
+        gom.count(PropositionView::class.java, PropositionViewQueryDsl.INSTANCE) {
+            orderBy { query.proposition.level.desc() }
+            seek { query.proposition.level after 4 }
+        }
+    }
 
     // edge cases
     assertTrue(load { limit(0) }.isEmpty(), "limit(0) -> empty")

--- a/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
+++ b/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.drivine.query.dsl
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class KeysetPlannerTest {
+
+    @Test
+    fun `compound descending cursor expands lexicographically and reuses bindings`() {
+        val instant = Instant.parse("2026-08-04T12:00:00Z")
+
+        val plan = KeysetPlanner.plan(
+            orders = listOf(
+                OrderSpec("session.lastActivityAt", OrderDirection.DESC),
+                OrderSpec("session.sessionId", OrderDirection.DESC),
+            ),
+            values = listOf(
+                SeekValueSpec("session.lastActivityAt", instant),
+                SeekValueSpec("session.sessionId", "s-20"),
+            ),
+        )
+
+        assertEquals(
+            "(session.lastActivityAt < \$_seek_0 OR " +
+                "(session.lastActivityAt = \$_seek_0 AND session.sessionId < \$_seek_1))",
+            plan.predicate,
+        )
+        assertEquals(mapOf("_seek_0" to instant, "_seek_1" to "s-20"), plan.bindings)
+    }
+
+    @Test
+    fun `mixed directions use the comparison belonging to each order`() {
+        val plan = KeysetPlanner.plan(
+            orders = listOf(
+                OrderSpec("n.priority", OrderDirection.DESC),
+                OrderSpec("n.name", OrderDirection.ASC),
+                OrderSpec("n.id", OrderDirection.DESC),
+            ),
+            values = listOf(
+                SeekValueSpec("n.priority", 10),
+                SeekValueSpec("n.name", "Ada"),
+                SeekValueSpec("n.id", "id-7"),
+            ),
+        )
+
+        assertEquals(
+            "(n.priority < \$_seek_0 OR " +
+                "(n.priority = \$_seek_0 AND n.name > \$_seek_1) OR " +
+                "(n.priority = \$_seek_0 AND n.name = \$_seek_1 AND n.id < \$_seek_2))",
+            plan.predicate,
+        )
+    }
+
+    @Test
+    fun `cursor paths and order paths must match`() {
+        val error = assertThrows<IllegalArgumentException> {
+            KeysetPlanner.plan(
+                orders = listOf(OrderSpec("n.createdAt", OrderDirection.DESC)),
+                values = listOf(SeekValueSpec("n.id", "id-1")),
+            )
+        }
+
+        assertEquals(
+            "seekAfter property #1 is n.id, but orderBy property #1 is n.createdAt",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `typed seekAfter DSL records cursor components`() {
+        data class TestQuery(
+            val activity: PropertyReference<Instant> = PropertyReference("n", "activity"),
+            val id: PropertyReference<String> = PropertyReference("n", "id"),
+        )
+
+        val instant = Instant.parse("2026-08-04T12:00:00Z")
+        val spec = GraphQuerySpec(TestQuery()).apply {
+            orderBy {
+                query.activity.desc()
+                query.id.desc()
+            }
+            seekAfter {
+                query.activity after instant
+                query.id after "id-7"
+            }
+        }
+
+        assertEquals(
+            listOf(
+                SeekValueSpec("n.activity", instant),
+                SeekValueSpec("n.id", "id-7"),
+            ),
+            spec.seekValues,
+        )
+    }
+
+    @Test
+    fun `null cursor values are rejected`() {
+        val property = PropertyReference<String?>("n", "nullable")
+        assertThrows<IllegalArgumentException> { property.after(null) }
+    }
+
+    @Test
+    fun `cursor values use the same database conversion as where bindings`() {
+        val id = UUID.fromString("018f5d6e-6d78-7c3a-9b2f-0123456789ab")
+
+        val plan = KeysetPlanner.plan(
+            orders = listOf(OrderSpec("n.id", OrderDirection.ASC)),
+            values = listOf(SeekValueSpec("n.id", id)),
+        )
+
+        assertEquals(id.toString(), plan.bindings["_seek_0"])
+    }
+}

--- a/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
+++ b/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
@@ -33,11 +33,22 @@ class KeysetPlannerTest {
         )
 
         assertEquals(
-            "(session.lastActivityAt < \$_seek_0 OR " +
-                "(session.lastActivityAt = \$_seek_0 AND session.sessionId < \$_seek_1))",
+            "(session.lastActivityAt <= \$_seek_0 AND " +
+                "(session.lastActivityAt < \$_seek_0 OR " +
+                "(session.lastActivityAt = \$_seek_0 AND session.sessionId < \$_seek_1)))",
             plan.predicate,
         )
         assertEquals(mapOf("_seek_0" to instant, "_seek_1" to "s-20"), plan.bindings)
+    }
+
+    @Test
+    fun `a single-key cursor is a bare comparison with no redundant bound`() {
+        val plan = KeysetPlanner.plan(
+            orders = listOf(OrderSpec("n.id", OrderDirection.ASC)),
+            values = listOf(SeekValueSpec("n.id", "id-7")),
+        )
+
+        assertEquals("(n.id > \$_seek_0)", plan.predicate)
     }
 
     @Test
@@ -56,10 +67,32 @@ class KeysetPlannerTest {
         )
 
         assertEquals(
-            "(n.priority < \$_seek_0 OR " +
+            "(n.priority <= \$_seek_0 AND " +
+                "(n.priority < \$_seek_0 OR " +
                 "(n.priority = \$_seek_0 AND n.name > \$_seek_1) OR " +
-                "(n.priority = \$_seek_0 AND n.name = \$_seek_1 AND n.id < \$_seek_2))",
+                "(n.priority = \$_seek_0 AND n.name = \$_seek_1 AND n.id < \$_seek_2)))",
             plan.predicate,
+        )
+    }
+
+    @Test
+    fun `an arity mismatch explains a collection sort that was routed away from root ordering`() {
+        val error = assertThrows<IllegalArgumentException> {
+            KeysetPlanner.plan(
+                orders = listOf(OrderSpec("issue.id", OrderDirection.DESC)),
+                values = listOf(
+                    SeekValueSpec("issue.id", "i-1"),
+                    SeekValueSpec("assignees.name", "Ada"),
+                ),
+                collectionSortCount = 1,
+            )
+        }
+
+        assertEquals(
+            "seek supplied 2 cursor values for 1 root orderBy properties " +
+                "(1 declared orderBy property sorts a relationship collection, which cannot " +
+                "participate in a keyset cursor)",
+            error.message,
         )
     }
 
@@ -73,13 +106,20 @@ class KeysetPlannerTest {
         }
 
         assertEquals(
-            "seekAfter property #1 is n.id, but orderBy property #1 is n.createdAt",
+            "seek property #1 is n.id, but orderBy property #1 is n.createdAt",
             error.message,
         )
     }
 
+    /**
+     * `after` is overloaded on [PropertyReference]: inside a [SeekBuilder] context it registers the
+     * value and returns `Unit`; outside one it returns a [SeekValueSpec] for Java callers. If the
+     * context overload ever stopped winning inside `seek { }`, every component would be silently
+     * discarded and this list would come back empty — so this test pins the resolution, not just
+     * the recording.
+     */
     @Test
-    fun `typed seekAfter DSL records cursor components`() {
+    fun `typed seek DSL records cursor components via the context overload`() {
         data class TestQuery(
             val activity: PropertyReference<Instant> = PropertyReference("n", "activity"),
             val id: PropertyReference<String> = PropertyReference("n", "id"),
@@ -91,7 +131,7 @@ class KeysetPlannerTest {
                 query.activity.desc()
                 query.id.desc()
             }
-            seekAfter {
+            seek {
                 query.activity after instant
                 query.id after "id-7"
             }
@@ -104,6 +144,13 @@ class KeysetPlannerTest {
             ),
             spec.seekValues,
         )
+    }
+
+    @Test
+    fun `outside a seek block the same call yields a value for Java callers`() {
+        val property = PropertyReference<String>("n", "id")
+
+        assertEquals(SeekValueSpec("n.id", "id-7"), property.after("id-7"))
     }
 
     @Test


### PR DESCRIPTION

  ## Description

  Adds first-class keyset pagination to Drivine4j's typed query DSL.

  The new API builds lexicographic seek predicates from the same ordered
  properties used by the query, allowing callers to implement stable,
  efficient pagination without manually constructing nested Cypher
  conditions.

  Both Kotlin and Java APIs are supported, including generated property
  references.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Code refactoring
  - [x] Performance improvement

  ## Changes Made

  - Add typed `seekAfter` keyset-pagination support to the Kotlin query DSL.
  - Add equivalent fluent support to `JavaQueryBuilder`.
  - Generate seek-capable property references through the code-generation module.
  - Build lexicographic predicates for mixed ascending and descending sort keys.
  - Convert cursor values through the existing property parameter-conversion path.
  - Add usage and ordering-semantics documentation to the README.
  - Set the next Drivine4j release version to `0.0.74`.

  ## Testing

  - [x] All existing tests pass
  - [x] New tests added for new functionality
  - [x] Manual testing completed

  The focused Kotlin and Java API tests passed locally. Cross-engine
  pagination coverage also passed against Neo4j, FalkorDB, and Memgraph.

  ### Test Coverage

  Added coverage for:

  - Single-property keyset pagination.
  - Compound lexicographic cursors.
  - Ascending and descending ordering.
  - Mixed ordering directions.
  - Null-policy handling.
  - Cursor arity validation.
  - Cursor parameter conversion.
  - Java fluent API usage.
  - Generated property references.
  - Neo4j, FalkorDB, and Memgraph query execution.

  ## Checklist

  - [x] My code follows the project's code style
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code where necessary
  - [x] My changes generate no known new warnings
  - [x] I have added tests that prove my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published (N/A: this PR has no upstream dependency changes)

  ## Related Issues

  Supports https://github.com/embabel/embabel-chat-store/issues/10

  ## Additional Notes

  This PR intentionally provides keyset-pagination primitives rather than
  embedding chat-store-specific ordering policy in Drivine4j.

  Callers must provide a deterministic ordering. When the leading sort
  property is not unique, a stable unique tie-breaker should be included as
  the final ordering property, for example:

  `lastActivityAt DESC, sessionId DESC`

  The corresponding cursor must contain values for both properties in the
  same order.