### PR TITLE
feat(query): index-aware keyset pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,29 +857,73 @@ comparison, so it is dropped from every page after the first — and engines dis
 nulls sort, so the shape of that loss is not even portable. Use non-null properties as keys, or
 filter nulls out in `where`.
 
-**Index the *leading* sort property on its own.** Keyset pagination is only cheap if the engine can
-seek into the index and stop; otherwise it scans the whole continuation and takes the top *n*, which
-is no better than `skip`. What unlocks the seek is an index whose leading column is the first
-`orderBy` property:
+**Index the cursor.** Keyset pagination is only cheap if the engine can seek into an index and stop;
+otherwise it scans the whole continuation and takes the top *n*, which is no better than `skip`. The
+rule is that the index mirrors the cursor — a range index over exactly the `orderBy` properties, in
+the same order:
 
 ```kotlin
-@RangeIndex
-val lastActivityAt: Instant
+@NodeFragment(labels = ["Session"])
+@RangeIndex(properties = ["lastActivityAt", "sessionId"])   // matches the cursor below
+data class SessionNode(
+    @NodeId val sessionId: String,
+    val lastActivityAt: Instant,
+)
+```
+```kotlin
+orderBy {
+    session.lastActivityAt.desc()
+    session.sessionId.desc()
+}
+seek {
+    session.lastActivityAt after cursor.lastActivityAt
+    session.sessionId after cursor.sessionId
+}
 ```
 
-Profiled on Neo4j 25, 200k nodes, a 20-row page taken from the middle of the relation:
+A single-property cursor takes a single-property index (`@RangeIndex` on the field) — same rule, one
+key. Profiled on Neo4j 25, 200k nodes, a 20-row page from the middle of the relation:
 
-| Index present | Database accesses |
+| Index | Database accesses |
 | --- | --- |
-| `RangeIndexSpec("Session", "lastActivityAt")` | **64** |
-| `RangeIndexSpec("Session", listOf("lastActivityAt", "sessionId"))` only | 600,010 |
-| neither | 900,011 |
+| Composite over both cursor keys | **27** |
+| Single-property on the leading key only | 200,020 |
+| None | 500,010 |
 
-The composite index is the trap: it looks like the right index for a two-property cursor, but Neo4j
-will not use a composite index for a predicate that constrains only its leading property, so the
-query falls back to a label scan. Declare the single-property index on the first sort key. A
-composite index alongside it is harmless, and useful for other queries — it just is not what makes
-paging fast.
+With the matching index the plan is `NodeIndexSeek` → `Limit` — no sort at all, since the index
+supplies the order, and it stops as soon as the page is full.
+
+Why an index that covers only *part* of the cursor is so much worse: Drivine constrains every cursor
+key with `IS NOT NULL`, because a Neo4j index excludes nodes that lack the property, so the planner
+will not use a composite index unless the query provably excludes those same nodes. That conjunct is
+what makes the composite index usable; against an index that doesn't contain the property, it is
+just an extra property read per row. Hence: mirror the cursor, and neither half of that applies.
+
+These numbers are measured on Neo4j. The predicate is exercised against FalkorDB and Memgraph in the
+cross-engine tests, but their planners have not been profiled — treat the index advice as Neo4j
+guidance until they are.
+
+**Drivine tells you when the index is missing.** Any root-level `orderBy` — with or without `seek` —
+is checked against the database's indexes, and reports when nothing mirrors it:
+
+```
+seek on Session(lastActivityAt, sessionId) has no matching range index, so the query scans and
+sorts instead of seeking. Declare @RangeIndex(properties = ["lastActivityAt", "sessionId"]) on the
+fragment, or call indexes.ensure(RangeIndexSpec("Session", listOf("lastActivityAt", "sessionId"))).
+The index must cover exactly these properties, in this order.
+```
+
+Ordering without an index is *correct*, just unindexed — perfectly reasonable on a small collection
+— so the default only warns, once per label/property combination. Turn it up in development or CI to
+make an unindexed page fail:
+
+```kotlin
+graphObjectManager.indexAdvice = IndexAdvicePolicy.FAIL   // WARN (default) | OFF
+```
+
+The index list is read once and cached per manager, so the check costs one round trip per process,
+not one per query. If your application ensures indexes lazily, after the first ordered query has
+already run, that cache will be stale — construct the manager after schema setup, or use `OFF`.
 
 `seek` rejects missing/misaligned order keys, null cursor values, use together with `skip`, and
 use on any operation that would ignore it (`count`, `deleteAll`, `loadNearest`, `loadMatching`) —

--- a/README.md
+++ b/README.md
@@ -914,16 +914,28 @@ The index must cover exactly these properties, in this order.
 ```
 
 Ordering without an index is *correct*, just unindexed — perfectly reasonable on a small collection
-— so the default only warns, once per label/property combination. Turn it up in development or CI to
-make an unindexed page fail:
+— so the default only warns, once per label/property combination. Turn it up in development or CI so
+an unindexed page fails the build instead of quietly scanning in production:
+
+```yaml
+drivine:
+  query:
+    index-advice: FAIL      # WARN (default) | OFF
+```
+
+The property applies to every manager the factory creates. Without Spring, or to override a single
+manager after it has been handed out:
 
 ```kotlin
-graphObjectManager.indexAdvice = IndexAdvicePolicy.FAIL   // WARN (default) | OFF
+graphObjectManager.indexAdvice = IndexAdvicePolicy.FAIL
 ```
 
 The index list is read once and cached per manager, so the check costs one round trip per process,
 not one per query. If your application ensures indexes lazily, after the first ordered query has
 already run, that cache will be stale — construct the manager after schema setup, or use `OFF`.
+
+See [docs/0.0.75-index-aware-keyset-pagination.md](docs/0.0.75-index-aware-keyset-pagination.md) for
+the planner reasoning behind the mirror rule, the full measurements, and the cross-engine caveats.
 
 `seek` rejects missing/misaligned order keys, null cursor values, use together with `skip`, and
 use on any operation that would ignore it (`count`, `deleteAll`, `loadNearest`, `loadMatching`) —

--- a/docs/0.0.75-index-aware-keyset-pagination.md
+++ b/docs/0.0.75-index-aware-keyset-pagination.md
@@ -1,0 +1,125 @@
+# Index-aware keyset pagination — `seek` + `IndexAdvicePolicy` — 0.0.75
+
+Maintainer handoff for two related changes: making the keyset predicate one a planner can actually
+seek on, and telling callers when the index it needs isn't there. Also backfills the `0.0.74`
+keyset-pagination feature, which shipped without a doc.
+
+## What shipped in 0.0.74
+
+Typed keyset pagination in the query DSL. The cursor mirrors the ordering, and Drivine expands it
+into the lexicographic continuation predicate:
+
+```kotlin
+graphObjectManager.loadAll<SessionView> {
+    orderBy {
+        session.lastActivityAt.desc()
+        session.sessionId.desc()
+    }
+    seek {
+        session.lastActivityAt after cursor.lastActivityAt
+        session.sessionId after cursor.sessionId
+    }
+    limit(pageSize)
+}
+```
+
+`seek` is rejected — rather than silently ignored — on `skip`, and on any operation that would not
+apply it (`count`, `deleteAll`, `loadNearest`, `loadMatching`). Java: `.seek(q -> List.of(...))` with
+`PropertyReference.after(value)`.
+
+## The contract: the index mirrors the cursor
+
+A range index over **exactly** the ordered properties, in the same order:
+
+```kotlin
+@NodeFragment(labels = ["Session"])
+@RangeIndex(properties = ["lastActivityAt", "sessionId"])
+data class SessionNode(...)
+```
+
+One cursor key takes a single-property index. Same rule, one key.
+
+## Why partial coverage is worse than none
+
+A Neo4j index excludes nodes that lack the property. So the planner will not answer from a composite
+index unless the query provably excludes those same nodes — otherwise it could silently drop rows.
+Given only `lastActivityAt <= $seek0`, a node missing `sessionId` might legitimately belong in the
+result, so the planner refuses the index and falls back to a label scan.
+
+`IS NOT NULL` on every cursor key is that proof. It is what makes the composite index usable at all.
+Against an index that does *not* contain the property, the same conjunct is pure cost — a property
+read per candidate row — which is why an index covering part of the cursor profiles worse than no
+index at all.
+
+Neo4j does this reasoning itself where it can; the pre-fix plan showed it synthesising
+`sessionId IS NOT NULL` on the one union branch where it could establish it.
+
+## Measured
+
+Neo4j 25, 200k nodes, 20-row page from mid-relation:
+
+| Index | Database accesses |
+| --- | --- |
+| Mirrors the cursor | **27** |
+| Leading property only | 200,020 |
+| None | 500,010 |
+
+Good plan is `NodeIndexSeek` → `Limit` — no sort, stops when the page is full. For reference, the
+0.0.74 predicate scored 600,010 against the mirroring index and 64 against a leading-property index;
+no single predicate is good under both index shapes, which is why the contract picks one.
+
+**Measured on Neo4j only.** The predicate is exercised against FalkorDB and Memgraph in the
+cross-engine tests, but neither planner has been profiled. Treat the index advice as Neo4j guidance.
+
+## Index advice
+
+Any root-level `orderBy`, with or without `seek`, is checked against the database's indexes:
+
+```yaml
+drivine:
+  query:
+    index-advice: FAIL      # WARN (default) | OFF
+```
+
+Ordering without an index is *correct*, just unindexed — reasonable on a small collection — so this
+is advice, not validation. `WARN` logs once per label/property combination. `FAIL` is for development
+and CI. Introspection failure degrades to silence rather than breaking a query that would otherwise
+run.
+
+## Behaviour changes (pre-1.0)
+
+- The emitted keyset predicate changed. Anyone who tuned indexes against `0.0.74`'s predicate — that
+  is, created a single-property index on the leading sort key — should switch to an index mirroring
+  the cursor, or they land on the 200,020 row above.
+- `indexAdvice` defaults to `WARN`, so applications ordering without a matching index will start
+  logging where they previously did not.
+- README guidance from `5feebcb` ("index the leading sort property on its own") was measured against
+  the old predicate and is superseded.
+
+## Code map
+
+- `query/dsl/KeysetPlanner.kt` — predicate construction; `IS NOT NULL` conjuncts and the leading
+  range bound, with the rationale for both.
+- `query/dsl/QueryIndexAdvisor.kt` — index introspection, per-manager cache, dedup, policy.
+- `manager/GraphObjectManager.kt` — `indexAdvice` property; `adviseOnIndexes` at plan time.
+- `manager/GraphObjectManagerFactory.kt` — carries the policy to every manager it creates.
+- `autoconfigure/DrivineQueryProperties.kt` — the Spring property.
+
+## Tests
+
+- `KeysetPlannerTest` — predicate shape for single-key, compound, and mixed-direction cursors.
+- `QueryIndexAdvisorTest` — against a real Neo4j, so introspection is exercised rather than mocked.
+  Covers the two cases that matter: an index over *part* of the ordering does not count, and neither
+  does one with the right properties in the wrong order.
+- `LimitSkipCrossEngineTest` — cursor walk and `where` + `seek` composition on all three engines.
+
+## Follow-ups
+
+- Profile FalkorDB and Memgraph, and either confirm the advice or make it engine-aware.
+- The starter module has no test source set, so `drivine.query.index-advice` binding is compile
+  checked but untested.
+- Null sort keys are documented, not enforced. Model nullability is the wrong hook — it describes the
+  class, not the graph, and `NullPolicy.IGNORE` makes the gap routine. A property-existence
+  constraint is the only place it could actually be guaranteed.
+- The advisor caches the index list per manager; an application ensuring indexes lazily after the
+  first ordered query will see a stale cache.

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
@@ -5,6 +5,7 @@ import org.drivine.connection.DatabaseRegistry
 import org.drivine.manager.GraphObjectManagerFactory
 import org.drivine.manager.PersistenceManagerFactory
 import org.drivine.mapper.Neo4jObjectMapper
+import org.drivine.query.dsl.IndexAdvicePolicy
 import org.drivine.transaction.DrivineTransactionManager
 import org.drivine.transaction.TransactionContextHolder
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -56,8 +57,14 @@ class DrivineConfiguration {
     @ConditionalOnMissingBean
     fun graphObjectManagerFactory(
         persistenceManagerFactory: PersistenceManagerFactory,
-        subtypeRegistry: org.drivine.mapper.SubtypeRegistry
+        subtypeRegistry: org.drivine.mapper.SubtypeRegistry,
+        queryProperties: DrivineQueryProperties?,
     ): GraphObjectManagerFactory {
-        return GraphObjectManagerFactory(persistenceManagerFactory, Neo4jObjectMapper.instance, subtypeRegistry)
+        return GraphObjectManagerFactory(
+            persistenceManagerFactory,
+            Neo4jObjectMapper.instance,
+            subtypeRegistry,
+            queryProperties?.indexAdvice ?: IndexAdvicePolicy.WARN,
+        )
     }
 }

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineQueryProperties.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineQueryProperties.kt
@@ -1,0 +1,26 @@
+package org.drivine.autoconfigure
+
+import org.drivine.query.dsl.IndexAdvicePolicy
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Query-time behaviour that is not about connecting or about schema enforcement.
+ *
+ * ```yaml
+ * drivine:
+ *   query:
+ *     index-advice: FAIL      # WARN (default) | OFF
+ * ```
+ */
+@ConfigurationProperties(prefix = "drivine.query")
+data class DrivineQueryProperties(
+    /**
+     * What to do when an ordered or keyset-paginated query has no range index to seek into.
+     *
+     * `WARN` logs once per label/property combination. `FAIL` throws — intended for development and
+     * CI, where an unindexed page should fail the build rather than quietly scan in production.
+     * `OFF` says nothing; ordering without an index is correct, just unindexed, which is a
+     * reasonable thing to do on a small collection.
+     */
+    var indexAdvice: IndexAdvicePolicy = IndexAdvicePolicy.WARN,
+)

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivine.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivine.kt
@@ -44,6 +44,6 @@ import kotlin.annotation.AnnotationTarget.CLASS
  */
 @Target(CLASS)
 @Retention(RUNTIME)
-@EnableConfigurationProperties(DrivineSchemaProperties::class)
+@EnableConfigurationProperties(DrivineSchemaProperties::class, DrivineQueryProperties::class)
 @Import(DrivineConfiguration::class, DrivineSchemaConfiguration::class)
 annotation class EnableDrivine

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivinePropertiesConfig.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivinePropertiesConfig.kt
@@ -44,6 +44,6 @@ import kotlin.annotation.AnnotationTarget.CLASS
  */
 @Target(CLASS)
 @Retention(RUNTIME)
-@EnableConfigurationProperties(DrivineProperties::class)
+@EnableConfigurationProperties(DrivineProperties::class, DrivineQueryProperties::class)
 @Import(DrivinePropertiesConfiguration::class)
 annotation class EnableDrivinePropertiesConfig

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivineTestConfig.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/EnableDrivineTestConfig.kt
@@ -87,6 +87,6 @@ import kotlin.annotation.AnnotationTarget.CLASS
  */
 @Target(CLASS)
 @Retention(RUNTIME)
-@EnableConfigurationProperties(DrivineProperties::class)
+@EnableConfigurationProperties(DrivineProperties::class, DrivineQueryProperties::class)
 @Import(DrivineTestConfiguration::class)
 annotation class EnableDrivineTestConfig

--- a/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
+++ b/src/main/kotlin/org/drivine/manager/GraphObjectManager.kt
@@ -19,6 +19,9 @@ import org.drivine.query.dsl.CypherGenerator
 import org.drivine.query.dsl.GraphQuerySpec
 import org.drivine.query.dsl.OrderClauseResult
 import org.drivine.query.dsl.KeysetPlanner
+import org.drivine.query.dsl.IndexAdvicePolicy
+import org.drivine.query.dsl.OrderSpec
+import org.drivine.query.dsl.QueryIndexAdvisor
 import org.drivine.session.SessionManager
 
 /**
@@ -53,6 +56,18 @@ class GraphObjectManager(
     private val grammar = persistenceManager.grammar
 
     private val batchSave = BatchSaveOperations(objectMapper, sessionManager, UNWIND_CHUNK_SIZE, grammar)
+
+    private val indexAdvisor = QueryIndexAdvisor(persistenceManager.indexes)
+
+    /**
+     * What to do when an ordered or keyset-paginated query has no range index to seek into.
+     *
+     * Defaults to [IndexAdvicePolicy.WARN], which logs once per distinct label/property combination.
+     * Set [IndexAdvicePolicy.FAIL] in development or CI to turn an unindexed page into an error, or
+     * [IndexAdvicePolicy.OFF] to say nothing — ordering without an index is correct, just unindexed,
+     * and on a small collection that is a perfectly reasonable thing to do.
+     */
+    var indexAdvice: IndexAdvicePolicy = IndexAdvicePolicy.WARN
 
     /**
      * Loads all instances of a graph object (GraphView or GraphFragment) from the database.
@@ -330,6 +345,8 @@ class GraphObjectManager(
         }
         val effectiveBindings = ctx.bindings + (keysetPlan?.bindings ?: emptyMap())
 
+        adviseOnIndexes(graphClass, ctx.viewModel, orderResult.rootOrders, isKeyset = keysetPlan != null)
+
         val baseQuery = if (querySpec.depthOverrides.isNotEmpty() && builder is GraphViewQueryBuilder) {
             builder.buildQuery(effectiveWhereClause, orderResult.orderByClause, orderResult.collectionSorts, querySpec.depthOverrides, ctx.prologs, ctx.bridgeVariables)
         } else {
@@ -599,6 +616,33 @@ class GraphObjectManager(
         return scored
     }
 
+
+    /**
+     * Reports when an ordered query has no range index to seek into. See [indexAdvice] for the
+     * levels, and the README's pagination section for why the index must mirror the ordering
+     * exactly rather than merely overlap it.
+     *
+     * Only root-level orders participate — a collection sort happens inside a pattern comprehension,
+     * where no index applies.
+     */
+    private fun adviseOnIndexes(
+        graphClass: Class<*>,
+        viewModel: GraphViewModel?,
+        rootOrders: List<OrderSpec>,
+        isKeyset: Boolean,
+    ) {
+        if (indexAdvice == IndexAdvicePolicy.OFF || rootOrders.isEmpty()) return
+
+        val fragmentType = viewModel?.rootFragment?.fragmentType ?: graphClass
+        val label = FragmentModel.from(fragmentType).labels.firstOrNull() ?: return
+
+        indexAdvisor.check(
+            policy = indexAdvice,
+            label = label,
+            properties = rootOrders.map { it.propertyPath.substringAfter(".") },
+            operation = if (isKeyset) "seek" else "orderBy",
+        )
+    }
 
     /**
      * Builds query context from a GraphQuerySpec, extracting the view model, WHERE clause, and bindings.

--- a/src/main/kotlin/org/drivine/manager/GraphObjectManagerFactory.kt
+++ b/src/main/kotlin/org/drivine/manager/GraphObjectManagerFactory.kt
@@ -2,6 +2,7 @@ package org.drivine.manager
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.drivine.mapper.SubtypeRegistry
+import org.drivine.query.dsl.IndexAdvicePolicy
 import org.drivine.session.SessionManager
 
 /**
@@ -12,7 +13,12 @@ import org.drivine.session.SessionManager
 class GraphObjectManagerFactory(
     private val persistenceManagerFactory: PersistenceManagerFactory,
     private val objectMapper: ObjectMapper,
-    private val subtypeRegistry: SubtypeRegistry
+    private val subtypeRegistry: SubtypeRegistry,
+    /**
+     * Applied to every manager this factory creates. See [GraphObjectManager.indexAdvice]; an
+     * individual manager can still be turned up or down after it is handed out.
+     */
+    private val indexAdvice: IndexAdvicePolicy = IndexAdvicePolicy.WARN,
 ) {
     private val managers: MutableMap<String, GraphObjectManager> = mutableMapOf()
 
@@ -28,6 +34,7 @@ class GraphObjectManagerFactory(
             val persistenceManager = persistenceManagerFactory.get(database, type)
             val sessionManager = SessionManager(objectMapper)
             managers[key] = GraphObjectManager(persistenceManager, sessionManager, objectMapper, subtypeRegistry)
+                .apply { indexAdvice = this@GraphObjectManagerFactory.indexAdvice }
         }
         return managers[key]!!
     }

--- a/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/KeysetPlanner.kt
@@ -19,16 +19,26 @@ internal data class KeysetPlan(
  * Compiles root ordering plus cursor values into a lexicographic seek predicate.
  *
  * For `a DESC, b DESC` after `(A, B)` this emits:
- * `(a <= $_seek_0 AND (a < $_seek_0 OR (a = $_seek_0 AND b < $_seek_1)))`.
+ * `(a IS NOT NULL AND b IS NOT NULL AND a <= $_seek_0 AND
+ * (a < $_seek_0 OR (a = $_seek_0 AND b < $_seek_1)))`.
  *
- * The leading `a <= $_seek_0` is logically redundant — the disjunction already implies it — but a
- * top-level `OR` typically stops a planner from using an index on `a`, whereas the extra conjunct
- * gives it a range bound to seek on. It is omitted for a single-key cursor, where the predicate is
- * already a bare comparison.
+ * Two conjuncts are logically redundant — the disjunction implies both — and both exist to give the
+ * planner something to seek on, because a top-level `OR` otherwise forces a scan:
+ *
+ * - The leading `a <= $_seek_0` supplies a range bound on the first key. Omitted for a single-key
+ *   cursor, where the predicate is already a bare comparison.
+ * - `IS NOT NULL` on every key lets a *composite* index apply. A composite index is only usable when
+ *   every one of its properties is constrained, so without this the natural index for a compound
+ *   cursor — one over all the sort keys — cannot be used at all.
+ *
+ * Measured on Neo4j 25, 200k nodes, a 20-row page from mid-relation: 27 database accesses with both
+ * conjuncts against a composite index, against 600k with only the range bound and 900k with neither.
+ * The good plan is `NodeIndexSeek` → `Limit`, with no sort at all — the index supplies the order.
  *
  * **Nulls.** A row whose ordered property is null never satisfies a comparison, so it is dropped by
- * every page after the first. Engines also disagree on where nulls sort. Keyset properties must be
- * non-null in the data; see the README's pagination section.
+ * every page after the first. Engines also disagree on where nulls sort, so the explicit
+ * `IS NOT NULL` is what makes that exclusion identical everywhere rather than a per-engine accident.
+ * Keyset properties should be non-null in the data; see the README's pagination section.
  */
 internal object KeysetPlanner {
 
@@ -67,12 +77,19 @@ internal object KeysetPlanner {
             (equalPrefix + tail).joinToString(" AND ").let { if (branchIndex == 0) it else "($it)" }
         }
 
-        val disjunction = branches.joinToString(" OR ", prefix = "(", postfix = ")")
-        val predicate = if (orders.size == 1) {
-            disjunction
+        val disjunction = if (branches.size == 1) {
+            branches.single()
         } else {
-            "(${comparison(orders[0], strict = false, index = 0)} AND $disjunction)"
+            branches.joinToString(" OR ", prefix = "(", postfix = ")")
         }
+        val notNulls = orders.map { "${it.propertyPath} IS NOT NULL" }
+        val rangeBound = if (orders.size == 1) {
+            // A single key's comparison is already a usable range bound on its own.
+            emptyList()
+        } else {
+            listOf(comparison(orders[0], strict = false, index = 0))
+        }
+        val predicate = (notNulls + rangeBound + disjunction).joinToString(" AND ", "(", ")")
 
         return KeysetPlan(
             predicate = predicate,

--- a/src/main/kotlin/org/drivine/query/dsl/QueryIndexAdvisor.kt
+++ b/src/main/kotlin/org/drivine/query/dsl/QueryIndexAdvisor.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.drivine.query.dsl
+
+import org.drivine.schema.IndexManager
+import org.drivine.schema.SchemaItemInfo
+import org.drivine.schema.SchemaItemKind
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * What to do when an ordered query has no index to seek into.
+ *
+ * Ordering without a matching index is *correct* — it just scans and sorts, which is fine for a
+ * small collection and quietly expensive for a large one. So this is advice, not validation, and
+ * the level is the caller's to choose.
+ */
+enum class IndexAdvicePolicy {
+    /** Say nothing. */
+    OFF,
+
+    /** Log a warning, once per distinct label/property combination. The default. */
+    WARN,
+
+    /** Throw. Intended for development and CI, where an unindexed page should fail the build. */
+    FAIL,
+}
+
+/**
+ * Checks that an ordered or keyset-paginated query has a range index it can seek into, and reports
+ * when it does not.
+ *
+ * The rule is that **the index mirrors the cursor**: a range index over exactly the ordered
+ * properties, in the same order. Partial coverage does not help — see the pagination section of the
+ * README for why an index over only some cursor keys is worse than none.
+ *
+ * The database's index list is read once and cached for the life of this advisor, so the check costs
+ * one round trip per process rather than one per query. Schema created *after* the first check is
+ * therefore invisible to it; call [refresh] if an application ensures indexes lazily.
+ */
+internal class QueryIndexAdvisor(private val indexes: IndexManager) {
+
+    private val logger = LoggerFactory.getLogger(QueryIndexAdvisor::class.java)
+
+    @Volatile
+    private var cachedIndexes: List<SchemaItemInfo>? = null
+
+    /** Signatures already reported, so a warning fires once rather than once per page. */
+    private val reported = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Reports if no range index covers [properties] on [label].
+     *
+     * @param label the node label the ordering applies to
+     * @param properties the ordered properties, in `orderBy` order
+     * @param operation what the caller was doing, for the message ("seek", "orderBy")
+     */
+    fun check(policy: IndexAdvicePolicy, label: String, properties: List<String>, operation: String) {
+        if (policy == IndexAdvicePolicy.OFF || properties.isEmpty()) return
+        if (hasMatchingIndex(label, properties)) return
+
+        val signature = "$operation|$label|${properties.joinToString(",")}"
+        val message = advice(label, properties, operation)
+
+        when (policy) {
+            IndexAdvicePolicy.FAIL -> throw IllegalStateException(message)
+            IndexAdvicePolicy.WARN -> if (reported.add(signature)) logger.warn(message)
+            IndexAdvicePolicy.OFF -> Unit
+        }
+    }
+
+    /** Drops the cached index list, so the next check re-reads it from the database. */
+    fun refresh() {
+        cachedIndexes = null
+        reported.clear()
+    }
+
+    private fun hasMatchingIndex(label: String, properties: List<String>): Boolean =
+        indexList().any {
+            it.kind == SchemaItemKind.RANGE_INDEX && it.label == label && it.properties == properties
+        }
+
+    /**
+     * Reads the index list once. A failure to introspect (permissions, an engine that does not
+     * support it) yields an empty list rather than an error — advice must never break a query that
+     * would otherwise run.
+     */
+    private fun indexList(): List<SchemaItemInfo> = cachedIndexes ?: try {
+        indexes.list().also { cachedIndexes = it }
+    } catch (e: Exception) {
+        logger.debug("Could not introspect indexes for query index advice", e)
+        emptyList<SchemaItemInfo>().also { cachedIndexes = it }
+    }
+
+    private fun advice(label: String, properties: List<String>, operation: String): String {
+        val quoted = properties.joinToString(", ") { "\"$it\"" }
+        val declaration = if (properties.size == 1) {
+            "@RangeIndex on ${properties.single()}"
+        } else {
+            "@RangeIndex(properties = [$quoted])"
+        }
+        return "$operation on $label(${properties.joinToString(", ")}) has no matching range index, " +
+            "so the query scans and sorts instead of seeking. Declare $declaration on the fragment, " +
+            "or call indexes.ensure(RangeIndexSpec(\"$label\", listOf($quoted))). The index must " +
+            "cover exactly these properties, in this order."
+    }
+}

--- a/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
+++ b/src/test/kotlin/org/drivine/query/dsl/KeysetPlannerTest.kt
@@ -33,7 +33,8 @@ class KeysetPlannerTest {
         )
 
         assertEquals(
-            "(session.lastActivityAt <= \$_seek_0 AND " +
+            "(session.lastActivityAt IS NOT NULL AND session.sessionId IS NOT NULL AND " +
+                "session.lastActivityAt <= \$_seek_0 AND " +
                 "(session.lastActivityAt < \$_seek_0 OR " +
                 "(session.lastActivityAt = \$_seek_0 AND session.sessionId < \$_seek_1)))",
             plan.predicate,
@@ -48,7 +49,7 @@ class KeysetPlannerTest {
             values = listOf(SeekValueSpec("n.id", "id-7")),
         )
 
-        assertEquals("(n.id > \$_seek_0)", plan.predicate)
+        assertEquals("(n.id IS NOT NULL AND n.id > \$_seek_0)", plan.predicate)
     }
 
     @Test
@@ -67,7 +68,8 @@ class KeysetPlannerTest {
         )
 
         assertEquals(
-            "(n.priority <= \$_seek_0 AND " +
+            "(n.priority IS NOT NULL AND n.name IS NOT NULL AND n.id IS NOT NULL AND " +
+                "n.priority <= \$_seek_0 AND " +
                 "(n.priority < \$_seek_0 OR " +
                 "(n.priority = \$_seek_0 AND n.name > \$_seek_1) OR " +
                 "(n.priority = \$_seek_0 AND n.name = \$_seek_1 AND n.id < \$_seek_2)))",

--- a/src/test/kotlin/org/drivine/query/dsl/QueryIndexAdvisorTest.kt
+++ b/src/test/kotlin/org/drivine/query/dsl/QueryIndexAdvisorTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.drivine.query.dsl
+
+import org.drivine.connection.DatabaseType
+import org.drivine.connection.Neo4jConnectionProvider
+import org.drivine.manager.GraphObjectManager
+import org.drivine.manager.NonTransactionalPersistenceManager
+import org.drivine.mapper.Neo4jObjectMapper
+import org.drivine.mapper.SubtypeRegistry
+import org.drivine.query.QuerySpecification
+import org.drivine.query.grammar.CypherDialect
+import org.drivine.schema.RangeIndexSpec
+import org.drivine.session.SessionManager
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.testcontainers.containers.Neo4jContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import sample.proposition.PropositionView
+import sample.proposition.PropositionViewQueryDsl
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The index advisor, against a real engine so the introspection path is exercised rather than mocked.
+ *
+ * The rule under test is that the index must **mirror** the ordering — same properties, same order.
+ * Partial coverage does not count, because a composite index that only overlaps the cursor is the
+ * case that profiles worst (see the README's pagination section).
+ */
+@Testcontainers
+class QueryIndexAdvisorTest {
+
+    companion object {
+        private const val PASSWORD = "advisortest"
+
+        @Container @JvmField
+        val container: Neo4jContainer<*> = Neo4jContainer(DockerImageName.parse("neo4j:latest"))
+            .apply { withAdminPassword(PASSWORD) }
+
+        private lateinit var provider: Neo4jConnectionProvider
+        lateinit var pm: NonTransactionalPersistenceManager
+
+        @JvmStatic @BeforeAll
+        fun setup() {
+            val registry = SubtypeRegistry()
+            provider = Neo4jConnectionProvider(
+                name = "neo-advisor", type = DatabaseType.NEO4J,
+                host = container.host, port = container.getMappedPort(7687),
+                user = "neo4j", password = PASSWORD, database = "neo4j",
+                config = emptyMap(), subtypeRegistry = registry, cypherDialect = CypherDialect.NEO4J_5,
+            )
+            pm = NonTransactionalPersistenceManager(provider, "neo4j", DatabaseType.NEO4J, registry)
+        }
+
+        @JvmStatic @AfterAll
+        fun teardown() = provider.end()
+    }
+
+    private fun gom(): GraphObjectManager {
+        val mapper = Neo4jObjectMapper.instance
+        return GraphObjectManager(pm, SessionManager(mapper), mapper, SubtypeRegistry())
+    }
+
+    private fun GraphObjectManager.orderedLoad() =
+        loadAll(PropositionView::class.java, PropositionViewQueryDsl.INSTANCE) {
+            orderBy {
+                query.proposition.level.desc()
+                query.proposition.id.desc()
+            }
+            limit(2)
+        }
+
+    @BeforeEach
+    fun seed() {
+        pm.execute(QuerySpecification.withStatement("MATCH (n) DETACH DELETE n"))
+        pm.execute(
+            QuerySpecification.withStatement(
+                "CREATE (:Proposition {id: 'p1', contextId: 'c', status: 'active', level: 1})"
+            )
+        )
+        pm.indexes.list()
+            .filter { it.label == "Proposition" }
+            .mapNotNull { it.name }
+            .forEach { pm.execute(QuerySpecification.withStatement("DROP INDEX $it IF EXISTS")) }
+    }
+
+    @Test
+    fun `FAIL rejects an ordered query with no covering index, and names the fix`() {
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        val error = assertThrows<IllegalStateException> { manager.orderedLoad() }
+
+        assertTrue(error.message!!.contains("Proposition(level, id)"), error.message)
+        assertTrue(
+            error.message!!.contains("""@RangeIndex(properties = ["level", "id"])"""),
+            error.message,
+        )
+    }
+
+    @Test
+    fun `an index mirroring the ordering satisfies the advisor`() {
+        pm.indexes.ensure(RangeIndexSpec("Proposition", listOf("level", "id")))
+
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        assertEquals(1, manager.orderedLoad().size)
+    }
+
+    @Test
+    fun `an index over only part of the ordering does not count`() {
+        pm.indexes.ensure(RangeIndexSpec("Proposition", "level"))
+
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        assertThrows<IllegalStateException> { manager.orderedLoad() }
+    }
+
+    @Test
+    fun `an index with the same properties in the wrong order does not count`() {
+        pm.indexes.ensure(RangeIndexSpec("Proposition", listOf("id", "level")))
+
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        assertThrows<IllegalStateException> { manager.orderedLoad() }
+    }
+
+    @Test
+    fun `WARN and OFF never break a query that would otherwise run`() {
+        assertEquals(1, gom().apply { indexAdvice = IndexAdvicePolicy.WARN }.orderedLoad().size)
+        assertEquals(1, gom().apply { indexAdvice = IndexAdvicePolicy.OFF }.orderedLoad().size)
+    }
+
+    @Test
+    fun `an unordered query is never advised on`() {
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        assertEquals(1, manager.loadAll(PropositionView::class.java).size)
+        assertEquals(
+            1,
+            manager.loadAll(PropositionView::class.java, PropositionViewQueryDsl.INSTANCE) {
+                where { query.proposition.id eq "p1" }
+            }.size,
+        )
+    }
+
+    @Test
+    fun `a keyset cursor is advised on under its own operation name`() {
+        val manager = gom().apply { indexAdvice = IndexAdvicePolicy.FAIL }
+
+        val error = assertThrows<IllegalStateException> {
+            manager.loadAll(PropositionView::class.java, PropositionViewQueryDsl.INSTANCE) {
+                orderBy {
+                    query.proposition.level.desc()
+                    query.proposition.id.desc()
+                }
+                seek {
+                    query.proposition.level after 4
+                    query.proposition.id after "p4"
+                }
+                limit(2)
+            }
+        }
+
+        assertTrue(error.message!!.startsWith("seek on Proposition(level, id)"), error.message)
+    }
+}


### PR DESCRIPTION
## Description

Makes keyset pagination index-aware, and tells callers when an ordered query has no index to seek into.

Follows up #6. While profiling the predicate that shipped in `0.0.74`, it turned out the redundant leading bound only pays off against one particular index shape — and that the natural index for a compound cursor was the *slow* case.

## The mechanism

A Neo4j index excludes nodes that lack the property. So the planner will not use a composite index unless the query provably excludes those same nodes — otherwise answering from the index could silently drop rows. Without `IS NOT NULL`, an index over all the cursor keys cannot be used at all, and the query falls back to a label scan.

The rule that falls out: **the index mirrors the cursor** — a range index over exactly the ordered properties, in the same order.

```kotlin
@RangeIndex(properties = ["lastActivityAt", "sessionId"])
```
```kotlin
orderBy { session.lastActivityAt.desc(); session.sessionId.desc() }
seek    { session.lastActivityAt after cursor.lastActivityAt
          session.sessionId after cursor.sessionId }
```

Partial coverage is worse than none: `IS NOT NULL` on a property the index doesn't contain costs a read per row and buys nothing.

## Measured

Neo4j 25, 200k nodes, 20-row page from mid-relation:

| Index | Database accesses |
| --- | --- |
| Mirrors the cursor | **27** |
| Leading property only | 200,020 |
| None | 500,010 |

With the matching index the plan is `NodeIndexSeek` → `Limit` — no sort, and it stops when the page is full. For reference the `0.0.74` predicate scored 600,010 against the mirroring index and 64 against a leading-property index: no single predicate is good under both shapes, which is why the contract picks one.

A single-key cursor is the same rule with one key; `IS NOT NULL` is free there (42 accesses either way).

## Changes Made

- Constrain every cursor key with `IS NOT NULL` in `KeysetPlanner`.
- Add `QueryIndexAdvisor`, checking any root-level `orderBy` with or without `seek`.
- `drivine.query.index-advice` — `WARN` (default, deduplicated per label/property combination), `FAIL` for development and CI, `OFF` to silence. Carried through `GraphObjectManagerFactory`; `GraphObjectManager.indexAdvice` still overrides per manager.
- Rewrite the README pagination section around the mirror rule.
- Add `docs/0.0.75-index-aware-keyset-pagination.md`, which also backfills `0.0.74` — keyset pagination shipped without a `docs/` entry, breaking a convention unbroken since `0.0.48`.

## Testing

- [x] All existing tests pass — 837 tests, 0 failures
- [x] New tests added for new functionality
- [x] Cross-engine suite green on Neo4j, FalkorDB and Memgraph

`QueryIndexAdvisorTest` runs against a real Neo4j rather than a mock, so introspection is exercised. It covers the two cases that matter most: an index covering only *part* of the ordering does not count, and neither does one with the right properties in the wrong order.

## To decide before merge

**The advisor defaults to `WARN`**, so applications that order without a matching index will start logging. That is the intent, but it is a behaviour change — worth deciding whether it ships as `WARN` or `OFF`.

**This supersedes README guidance from `5feebcb`**, which told people to index the leading sort property alone. That was measured against the previous predicate and is now wrong.

**Version not bumped.** `build.gradle` is still at the published `0.0.74`, so this needs `0.0.75` on merge.

## Caveats

Measured on Neo4j only. The predicate runs against FalkorDB and Memgraph in the cross-engine tests, but neither planner has been profiled, so the index advice is Neo4j guidance for now.

The starter module has no test source set, so the `drivine.query.index-advice` binding is compile checked but not covered by a test.

The advisor caches the index list per manager. An application that ensures indexes lazily, after the first ordered query has run, will see a stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
