### PR TITLE
Treat a blank explicit schema-item name as absent

### DIFF
--- a/src/main/kotlin/org/drivine/schema/SchemaItemSpec.kt
+++ b/src/main/kotlin/org/drivine/schema/SchemaItemSpec.kt
@@ -26,9 +26,12 @@ sealed interface SchemaItemSpec {
 
     val kind: SchemaItemKind
 
-    /** The name used when creating the item, on engines that support names. */
+    /** The name used when creating the item, on engines that support names. A BLANK explicit name is
+     *  treated as absent (derive [defaultName]) — `@VectorIndex(name = "")` defaults to an empty string,
+     *  not null, and an empty name makes the engine reject the schema ("name cannot be the empty string").
+     *  Mirrors the query-side [org.drivine.query.VectorIndexResolver]'s `name.ifEmpty { … }`. */
     val effectiveName: String
-        get() = name ?: defaultName()
+        get() = name?.takeIf { it.isNotBlank() } ?: defaultName()
 
     fun defaultName(): String
 

--- a/src/test/kotlin/org/drivine/schema/Neo4jSchemaGrammarTest.kt
+++ b/src/test/kotlin/org/drivine/schema/Neo4jSchemaGrammarTest.kt
@@ -41,6 +41,21 @@ class Neo4jSchemaGrammarTest {
         assertTrue(statement.statement.contains("'euclidean'"))
     }
 
+    @Test
+    fun `vector index DDL derives the default name when the explicit name is BLANK, not just null`() {
+        // `@VectorIndex(name = "")` defaults to an EMPTY string (not null). A blank name MUST derive the
+        // default — otherwise the engine rejects the DDL with "name cannot be the empty string" (the dice
+        // Proposition_embedding_vector boot failure on a fresh Neo4j).
+        val spec = VectorIndexSpec("Proposition", "embedding", 1536, name = "")
+        val statement = grammar.createIndex(spec).single() as SchemaStatement.Cypher
+
+        assertTrue(
+            statement.statement.contains("CREATE VECTOR INDEX `Proposition_embedding_vector` IF NOT EXISTS"),
+            statement.statement,
+        )
+        assertFalse(statement.statement.contains("INDEX `` "), "must not emit an empty index name: ${statement.statement}")
+    }
+
     // ----- DDL: range index -----
 
     @Test


### PR DESCRIPTION
`@VectorIndex(name = "")` defaults to an **empty string**, not null, so `SchemaItemSpec.effectiveName` (`name ?: defaultName()`) emitted DDL with an empty index name and the engine rejected the whole schema — `name cannot be the empty string` — observed as a boot failure creating a vector index on a fresh Neo4j.

A blank name now derives `defaultName()`, mirroring the query-side `VectorIndexResolver`'s `name.ifEmpty { … }` treatment, so the two sides of the schema agree on what an unnamed index is called.

Test: `Neo4jSchemaGrammarTest` gains a case asserting a blank-named `VectorIndexSpec` emits ``CREATE VECTOR INDEX `Proposition_embedding_vector` IF NOT EXISTS`` and never an empty backticked name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9t8eRKuhBBNavdDpy15i4