### PR TITLE
IN_PROCESS engines register their own ConnectionProvider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.drivine'
-version = '0.0.79'
+version = '0.0.80-SNAPSHOT'
 
 base {
 	archivesName = 'drivine4j'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.drivine'
-version = '0.0.80-SNAPSHOT'
+version = '0.0.80'
 
 base {
 	archivesName = 'drivine4j'

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
@@ -29,7 +29,7 @@ class DrivineConfiguration {
     /**
      * [ConnectionProvider] beans register alongside the property-built
      * providers — the seam for engines connection properties cannot describe
-     * (an [org.drivine.connection.DatabaseType.IN_PROCESS] engine living in
+     * (an [org.drivine.connection.DatabaseType.EMBABEL] engine living in
      * the application itself). A bean whose name collides with a datasource
      * entry wins: application code outranks configuration.
      */

--- a/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
+++ b/drivine4j-spring-boot-starter/src/main/kotlin/org/drivine/autoconfigure/DrivineConfiguration.kt
@@ -26,10 +26,23 @@ class DrivineConfiguration {
         return org.drivine.mapper.SubtypeRegistry()
     }
 
+    /**
+     * [ConnectionProvider] beans register alongside the property-built
+     * providers — the seam for engines connection properties cannot describe
+     * (an [org.drivine.connection.DatabaseType.IN_PROCESS] engine living in
+     * the application itself). A bean whose name collides with a datasource
+     * entry wins: application code outranks configuration.
+     */
     @Bean
     @ConditionalOnMissingBean
-    fun databaseRegistry(dataSourceMap: DataSourceMap, subtypeRegistry: org.drivine.mapper.SubtypeRegistry): DatabaseRegistry {
-        return DatabaseRegistry(dataSourceMap, subtypeRegistry)
+    fun databaseRegistry(
+        dataSourceMap: DataSourceMap,
+        subtypeRegistry: org.drivine.mapper.SubtypeRegistry,
+        providers: org.springframework.beans.factory.ObjectProvider<org.drivine.connection.ConnectionProvider>,
+    ): DatabaseRegistry {
+        val registry = DatabaseRegistry(dataSourceMap, subtypeRegistry)
+        providers.orderedStream().forEach { registry.register(it) }
+        return registry
     }
 
     @Bean

--- a/src/main/kotlin/org/drivine/connection/ConnectionProperties.kt
+++ b/src/main/kotlin/org/drivine/connection/ConnectionProperties.kt
@@ -4,7 +4,8 @@ import org.drivine.query.grammar.CypherDialect
 
 data class ConnectionProperties(
     val type: DatabaseType,
-    val host: String,
+    /** Empty for engines with no wire — see [DatabaseType.buildableFromProperties]. */
+    val host: String = "",
     val port: Int? = null,
     val userName: String? = null,
     val password: String? = null,

--- a/src/main/kotlin/org/drivine/connection/ConnectionProviderBuilder.kt
+++ b/src/main/kotlin/org/drivine/connection/ConnectionProviderBuilder.kt
@@ -55,13 +55,18 @@ class ConnectionProviderBuilder(
 
     fun register(name: String = "default"): ConnectionProvider {
         registry.connectionProvider(name)?.let { return it }
-        requireNotNull(host) { "Host config is required" }
 
-        val provider = when (type) {
-            DatabaseType.IN_PROCESS -> throw DrivineException(
-                "IN_PROCESS engines supply their own ConnectionProvider — register it as a bean " +
+        /* Checked ahead of the host requirement: an engine with no wire has no
+         * host to be missing, so the caller needs directions, not a puzzle. */
+        type?.takeIf { !it.buildableFromProperties }?.let {
+            throw DrivineException(
+                "${it.value} engines supply their own ConnectionProvider — register it as a bean " +
                     "(or via DatabaseRegistry.register); connection properties cannot build one"
             )
+        }
+        require(!host.isNullOrBlank()) { "Host config is required" }
+
+        val provider = when (type) {
             DatabaseType.NEO4J -> buildNeo4jProvider(name)
             DatabaseType.NEPTUNE -> buildNeptuneProvider(name)
             DatabaseType.FALKORDB -> buildFalkorDbProvider(name)

--- a/src/main/kotlin/org/drivine/connection/ConnectionProviderBuilder.kt
+++ b/src/main/kotlin/org/drivine/connection/ConnectionProviderBuilder.kt
@@ -58,6 +58,10 @@ class ConnectionProviderBuilder(
         requireNotNull(host) { "Host config is required" }
 
         val provider = when (type) {
+            DatabaseType.IN_PROCESS -> throw DrivineException(
+                "IN_PROCESS engines supply their own ConnectionProvider — register it as a bean " +
+                    "(or via DatabaseRegistry.register); connection properties cannot build one"
+            )
             DatabaseType.NEO4J -> buildNeo4jProvider(name)
             DatabaseType.NEPTUNE -> buildNeptuneProvider(name)
             DatabaseType.FALKORDB -> buildFalkorDbProvider(name)

--- a/src/main/kotlin/org/drivine/connection/DatabaseRegistry.kt
+++ b/src/main/kotlin/org/drivine/connection/DatabaseRegistry.kt
@@ -15,7 +15,12 @@ class DatabaseRegistry(
 
     init {
         dataSourceMap.dataSources.forEach { (key, value) ->
-            withProperties(value).register(key)
+            /* An IN_PROCESS entry names and types the datasource for property
+             * binding, but its provider is code, not configuration — the
+             * application registers it (bean or [register]) after construction. */
+            if (value.type != DatabaseType.IN_PROCESS) {
+                withProperties(value).register(key)
+            }
         }
     }
 

--- a/src/main/kotlin/org/drivine/connection/DatabaseRegistry.kt
+++ b/src/main/kotlin/org/drivine/connection/DatabaseRegistry.kt
@@ -15,10 +15,11 @@ class DatabaseRegistry(
 
     init {
         dataSourceMap.dataSources.forEach { (key, value) ->
-            /* An IN_PROCESS entry names and types the datasource for property
-             * binding, but its provider is code, not configuration — the
-             * application registers it (bean or [register]) after construction. */
-            if (value.type != DatabaseType.IN_PROCESS) {
+            /* An entry for an engine with no wire names and types the
+             * datasource for property binding, but its provider is code, not
+             * configuration — the application registers it (bean or [register])
+             * after construction. */
+            if (value.type.buildableFromProperties) {
                 withProperties(value).register(key)
             }
         }

--- a/src/main/kotlin/org/drivine/connection/DatabaseType.kt
+++ b/src/main/kotlin/org/drivine/connection/DatabaseType.kt
@@ -5,7 +5,15 @@ enum class DatabaseType(val value: String) {
     POSTGRES("POSTGRES"),
     NEPTUNE("NEPTUNE"),
     FALKORDB("FALKORDB"),
-    MEMGRAPH("MEMGRAPH");
+    MEMGRAPH("MEMGRAPH"),
+
+    /**
+     * An engine living inside the application process — no wire, no container.
+     * Connection properties cannot build one: the application supplies its own
+     * [ConnectionProvider] (as a Spring bean with the starter, or via
+     * [DatabaseRegistry.register]).
+     */
+    IN_PROCESS("IN_PROCESS");
 
     companion object {
         fun fromValue(value: String): DatabaseType? {

--- a/src/main/kotlin/org/drivine/connection/DatabaseType.kt
+++ b/src/main/kotlin/org/drivine/connection/DatabaseType.kt
@@ -1,6 +1,19 @@
 package org.drivine.connection
 
-enum class DatabaseType(val value: String) {
+/**
+ * The engine a datasource speaks. Members name engines, not deployment
+ * topologies: [buildableFromProperties] carries the one topology fact the
+ * registry needs — whether host/port can describe a connection at all.
+ */
+enum class DatabaseType(
+    val value: String,
+    /**
+     * Whether [ConnectionProviderBuilder] can build a provider for this engine
+     * from connection properties. False for engines with no wire to describe;
+     * the application registers a [ConnectionProvider] instead.
+     */
+    val buildableFromProperties: Boolean = true,
+) {
     NEO4J("NEO4J"),
     POSTGRES("POSTGRES"),
     NEPTUNE("NEPTUNE"),
@@ -8,12 +21,13 @@ enum class DatabaseType(val value: String) {
     MEMGRAPH("MEMGRAPH"),
 
     /**
-     * An engine living inside the application process — no wire, no container.
-     * Connection properties cannot build one: the application supplies its own
-     * [ConnectionProvider] (as a Spring bean with the starter, or via
-     * [DatabaseRegistry.register]).
+     * Embabel's Cypher engine — compiler, evaluator and store living inside the
+     * application process, with no wire and no container. Connection properties
+     * cannot build one, so the application supplies its own [ConnectionProvider]
+     * (as a Spring bean with the starter, or via [DatabaseRegistry.register]).
      */
-    IN_PROCESS("IN_PROCESS");
+    EMBABEL("EMBABEL", buildableFromProperties = false),
+    ;
 
     companion object {
         fun fromValue(value: String): DatabaseType? {

--- a/src/main/kotlin/org/drivine/connection/NativeDriverSource.kt
+++ b/src/main/kotlin/org/drivine/connection/NativeDriverSource.kt
@@ -1,0 +1,31 @@
+package org.drivine.connection
+
+/**
+ * Capability interface for connection providers that can hand out the engine's own client
+ * object — the type application code would otherwise construct for itself.
+ *
+ * Maintenance paths (reconcilers, backfills, migrations) sometimes speak an engine's client
+ * library directly rather than going through [Connection] and
+ * [org.drivine.query.QuerySpecification]. Rebuilding that client from connection properties
+ * works, but opens a second connection pool and silently drifts from the configuration the
+ * provider used; for an engine living inside the application process there is nothing to
+ * rebuild at all, and only the provider can supply an implementation.
+ *
+ * Not every engine has one to give: providers that cannot answer simply do not implement this,
+ * so a caller's `as?` yields null and the absence is a typed answer rather than a failure.
+ *
+ * ```
+ * val driver = (provider as? NativeDriverSource<*>)?.nativeDriver as? Driver
+ *     ?: error("$forWhom speaks the bolt driver directly; ${provider.type} has none")
+ * ```
+ *
+ * The returned object is owned by the provider: it is closed by [ConnectionProvider.end], and
+ * callers must not close it themselves.
+ *
+ * @param T the engine's client type, e.g. `org.neo4j.driver.Driver`.
+ */
+interface NativeDriverSource<T : Any> {
+
+    /** The provider's own client instance, configured exactly as its [Connection]s are. */
+    val nativeDriver: T
+}

--- a/src/main/kotlin/org/drivine/connection/Neo4jConnectionProvider.kt
+++ b/src/main/kotlin/org/drivine/connection/Neo4jConnectionProvider.kt
@@ -25,7 +25,7 @@ class Neo4jConnectionProvider(
     private val config: Map<String, Any>,
     override val subtypeRegistry: SubtypeRegistry? = null,
     override val cypherDialect: CypherDialect = CypherDialect.NEO4J_5,
-) : ConnectionProvider {
+) : ConnectionProvider, NativeDriverSource<Driver> {
 
     private val driver: Driver = run {
         val driverConfig = Config.builder().apply {
@@ -58,6 +58,13 @@ class Neo4jConnectionProvider(
             }
         }
     }
+
+    /**
+     * The bolt driver backing this provider — same pool, same timeouts, same TLS and auth as
+     * the sessions [connect] hands out. Closed by [end]; do not close it here.
+     */
+    override val nativeDriver: Driver
+        get() = driver
 
     override fun connect(): Connection {
         val session: Session = if (database != null && type != DatabaseType.NEPTUNE) {

--- a/src/test/kotlin/org/drivine/connection/EmbabelEngineProviderSpiTest.kt
+++ b/src/test/kotlin/org/drivine/connection/EmbabelEngineProviderSpiTest.kt
@@ -9,12 +9,13 @@ import org.drivine.transaction.TransactionContextHolder
 import org.junit.jupiter.api.Test
 
 /**
- * The IN_PROCESS seam: an engine living inside the application supplies its
- * own [ConnectionProvider] instead of connection properties. The registry
- * accepts it, the persistence-manager stack builds over it generically, and
- * the property path fails with directions rather than a puzzle.
+ * The seam for an engine with no wire ([DatabaseType.buildableFromProperties]
+ * false): it supplies its own [ConnectionProvider] instead of connection
+ * properties. The registry accepts it, the persistence-manager stack builds
+ * over it generically, and the property path fails with directions rather
+ * than a puzzle.
  */
-class InProcessProviderSpiTest {
+class EmbabelEngineProviderSpiTest {
 
     private class FakeInProcessConnection : Connection {
         override fun sessionId(): String = "in-process"
@@ -30,18 +31,18 @@ class InProcessProviderSpiTest {
     }
 
     private class FakeInProcessProvider(override val name: String) : ConnectionProvider {
-        override val type: DatabaseType = DatabaseType.IN_PROCESS
+        override val type: DatabaseType = DatabaseType.EMBABEL
         override val subtypeRegistry: org.drivine.mapper.SubtypeRegistry? = null
         override fun connect(): Connection = FakeInProcessConnection()
         override fun end() = Unit
     }
 
     @Test
-    fun `an IN_PROCESS datasource entry is left for the application's provider`() {
+    fun `a wireless datasource entry is left for the application's provider`() {
         val registry = DatabaseRegistry(
             DataSourceMap(
                 mutableMapOf(
-                    "graph" to ConnectionProperties(type = DatabaseType.IN_PROCESS, host = "unused"),
+                    "graph" to ConnectionProperties(type = DatabaseType.EMBABEL),
                 ),
             ),
         )
@@ -49,7 +50,7 @@ class InProcessProviderSpiTest {
 
         registry.register(FakeInProcessProvider("graph"))
         assertThat(registry.connectionProvider("graph")).isNotNull
-        assertThat(registry.connectionProvider("graph")!!.type).isEqualTo(DatabaseType.IN_PROCESS)
+        assertThat(registry.connectionProvider("graph")!!.type).isEqualTo(DatabaseType.EMBABEL)
     }
 
     @Test
@@ -63,18 +64,26 @@ class InProcessProviderSpiTest {
             QuerySpecification.withStatement("RETURN 1").transform(String::class.java),
         )
         assertThat(rows).containsExactly("mapped-by-the-engine")
-        assertThat(manager.type).isEqualTo(DatabaseType.IN_PROCESS)
+        assertThat(manager.type).isEqualTo(DatabaseType.EMBABEL)
     }
 
     @Test
-    fun `connection properties cannot build an IN_PROCESS provider, and say so`() {
+    fun `connection properties cannot build an EMBABEL provider, and say so`() {
         val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
         assertThatThrownBy {
             registry.builder()
-                .withType(DatabaseType.IN_PROCESS)
-                .host("irrelevant")
+                .withType(DatabaseType.EMBABEL)
                 .register("graph")
         }.isInstanceOf(DrivineException::class.java)
-            .hasMessageContaining("register it as a bean")
+            .hasMessageContaining("EMBABEL engines supply their own ConnectionProvider")
+    }
+
+    @Test
+    fun `a wire engine still requires a host`() {
+        val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
+        assertThatThrownBy {
+            registry.builder().withType(DatabaseType.NEO4J).register("graph")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Host config is required")
     }
 }

--- a/src/test/kotlin/org/drivine/connection/InProcessProviderSpiTest.kt
+++ b/src/test/kotlin/org/drivine/connection/InProcessProviderSpiTest.kt
@@ -1,0 +1,80 @@
+package org.drivine.connection
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.drivine.DrivineException
+import org.drivine.manager.PersistenceManagerFactory
+import org.drivine.query.QuerySpecification
+import org.drivine.transaction.TransactionContextHolder
+import org.junit.jupiter.api.Test
+
+/**
+ * The IN_PROCESS seam: an engine living inside the application supplies its
+ * own [ConnectionProvider] instead of connection properties. The registry
+ * accepts it, the persistence-manager stack builds over it generically, and
+ * the property path fails with directions rather than a puzzle.
+ */
+class InProcessProviderSpiTest {
+
+    private class FakeInProcessConnection : Connection {
+        override fun sessionId(): String = "in-process"
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> query(spec: QuerySpecification<T>): List<T> =
+            listOf("mapped-by-the-engine") as List<T>
+
+        override fun startTransaction() = Unit
+        override fun commitTransaction() = Unit
+        override fun rollbackTransaction() = Unit
+        override fun release(error: Throwable?) = Unit
+    }
+
+    private class FakeInProcessProvider(override val name: String) : ConnectionProvider {
+        override val type: DatabaseType = DatabaseType.IN_PROCESS
+        override val subtypeRegistry: org.drivine.mapper.SubtypeRegistry? = null
+        override fun connect(): Connection = FakeInProcessConnection()
+        override fun end() = Unit
+    }
+
+    @Test
+    fun `an IN_PROCESS datasource entry is left for the application's provider`() {
+        val registry = DatabaseRegistry(
+            DataSourceMap(
+                mutableMapOf(
+                    "graph" to ConnectionProperties(type = DatabaseType.IN_PROCESS, host = "unused"),
+                ),
+            ),
+        )
+        assertThat(registry.connectionProvider("graph")).isNull()
+
+        registry.register(FakeInProcessProvider("graph"))
+        assertThat(registry.connectionProvider("graph")).isNotNull
+        assertThat(registry.connectionProvider("graph")!!.type).isEqualTo(DatabaseType.IN_PROCESS)
+    }
+
+    @Test
+    fun `the persistence-manager stack builds generically over a registered provider`() {
+        val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
+        registry.register(FakeInProcessProvider("graph"))
+        val factory = PersistenceManagerFactory(registry, TransactionContextHolder(registry))
+
+        val manager = factory.get("graph")
+        val rows: List<String> = manager.query(
+            QuerySpecification.withStatement("RETURN 1").transform(String::class.java),
+        )
+        assertThat(rows).containsExactly("mapped-by-the-engine")
+        assertThat(manager.type).isEqualTo(DatabaseType.IN_PROCESS)
+    }
+
+    @Test
+    fun `connection properties cannot build an IN_PROCESS provider, and say so`() {
+        val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
+        assertThatThrownBy {
+            registry.builder()
+                .withType(DatabaseType.IN_PROCESS)
+                .host("irrelevant")
+                .register("graph")
+        }.isInstanceOf(DrivineException::class.java)
+            .hasMessageContaining("register it as a bean")
+    }
+}

--- a/src/test/kotlin/org/drivine/connection/NativeDriverSourceTest.kt
+++ b/src/test/kotlin/org/drivine/connection/NativeDriverSourceTest.kt
@@ -1,0 +1,80 @@
+package org.drivine.connection
+
+import org.assertj.core.api.Assertions.assertThat
+import org.drivine.query.QuerySpecification
+import org.junit.jupiter.api.Test
+import org.neo4j.driver.Driver
+
+/**
+ * [NativeDriverSource] is how maintenance code that speaks an engine's own client library
+ * gets one: from the provider that built it, rather than by rebuilding it from properties
+ * (a second pool, drifting config) or reaching into provider internals. Engines with no
+ * such client do not implement it, so absence is a typed answer.
+ */
+class NativeDriverSourceTest {
+
+    private fun neo4jProvider() = Neo4jConnectionProvider(
+        name = "test",
+        type = DatabaseType.NEO4J,
+        host = "localhost",
+        port = 7687,
+        user = "neo4j",
+        password = "unused",
+        database = null,
+        protocol = "bolt",
+        config = emptyMap(),
+    )
+
+    @Test
+    fun `a bolt provider hands out its own driver, not a fresh one`() {
+        val provider = neo4jProvider()
+        try {
+            val driver = (provider as? NativeDriverSource<*>)?.nativeDriver
+            assertThat(driver).isInstanceOf(Driver::class.java)
+            /* The provider's instance, so callers share its pool and configuration —
+             * a rebuilt driver would differ on each read. */
+            assertThat(provider.nativeDriver).isSameAs(driver)
+        } finally {
+            provider.end()
+        }
+    }
+
+    @Test
+    fun `a provider with no native client simply does not implement the capability`() {
+        val provider = object : ConnectionProvider {
+            override val name = "graph"
+            override val type = DatabaseType.EMBABEL
+            override val subtypeRegistry = null
+            override fun connect(): Connection = throw UnsupportedOperationException()
+            override fun end() = Unit
+        }
+
+        assertThat(provider as? NativeDriverSource<*>).isNull()
+    }
+
+    @Test
+    fun `an in-process provider can supply a client of its own`() {
+        val stand = object : Connection {
+            override fun sessionId() = "in-process"
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Any> query(spec: QuerySpecification<T>): List<T> = emptyList<Any>() as List<T>
+            override fun startTransaction() = Unit
+            override fun commitTransaction() = Unit
+            override fun rollbackTransaction() = Unit
+            override fun release(error: Throwable?) = Unit
+        }
+        /* Engines with no wire implement the client rather than dialling one; the capability
+         * is what lets them answer at all. Modelled here with Connection standing in for a
+         * driver type drivine4j does not depend on. */
+        val provider = object : ConnectionProvider, NativeDriverSource<Connection> {
+            override val name = "graph"
+            override val type = DatabaseType.EMBABEL
+            override val subtypeRegistry = null
+            override val nativeDriver: Connection = stand
+            override fun connect(): Connection = stand
+            override fun end() = Unit
+        }
+
+        assertThat((provider as NativeDriverSource<*>).nativeDriver).isSameAs(stand)
+    }
+}


### PR DESCRIPTION
An engine living inside the application process — embedded or in-memory — has no host/port for connection properties, yet everything above the `Connection` seam is already generic: `PersistenceManagerFactory` builds transactional/non-transactional/delegating managers from whatever provider the registry returns. This PR makes that seam reachable from the outside:

- **`DatabaseType.IN_PROCESS`** — names the case so a datasource entry can bind it from configuration.
- **`DatabaseRegistry`** skips IN_PROCESS entries at construction: the entry names and types the datasource; the provider is code.
- **`ConnectionProviderBuilder`** answers IN_PROCESS with directions ("register a ConnectionProvider bean…") instead of a missing-host puzzle.
- **The starter's `databaseRegistry` bean** registers any `ConnectionProvider` beans after the property-built ones. Name collision → the bean wins: application code outranks configuration.

`InProcessProviderSpiTest` drives a fake in-process provider through the real `PersistenceManagerFactory` (query mapping, type, and the builder's error contract). No behavior change for any wire engine — the new enum member is inert unless a provider bean exists.

First consumer: the Embabel assistant's in-JVM Virtual Cypher engine (embabel/me#1058), which currently substitutes at the PersistenceManager *bean* level for want of exactly this seam — with this released, that collapses to one registered provider and the assistant deletes a reflection workaround and two conditional gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdQXEUdPYS6e7yyCdLAL2y