### PR TITLE
Ask a PersistenceManager whether it can manage schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.drivine'
-version = '0.0.80'
+version = '0.0.81'
 
 base {
 	archivesName = 'drivine4j'

--- a/src/main/kotlin/org/drivine/manager/DelegatingPersistenceManager.kt
+++ b/src/main/kotlin/org/drivine/manager/DelegatingPersistenceManager.kt
@@ -24,6 +24,9 @@ class DelegatingPersistenceManager(
      * Schema operations always route to the non-transactional manager — DDL must run in
      * auto-commit mode regardless of any transaction in flight.
      */
+    override val supportsSchemaManagement: Boolean
+        get() = factory.get(database, PersistenceManagerType.NON_TRANSACTIONAL).supportsSchemaManagement
+
     override val indexes: IndexManager
         get() = factory.get(database, PersistenceManagerType.NON_TRANSACTIONAL).indexes
 

--- a/src/main/kotlin/org/drivine/manager/NonTransactionalPersistenceManager.kt
+++ b/src/main/kotlin/org/drivine/manager/NonTransactionalPersistenceManager.kt
@@ -20,6 +20,9 @@ class NonTransactionalPersistenceManager(
     override val grammar: CypherGrammar
         get() = connectionProvider.grammar
 
+    override val supportsSchemaManagement: Boolean
+        get() = connectionProvider.supportsSchemaManagement
+
     override val indexes: IndexManager by lazy { IndexManager(connectionProvider) }
 
     override val constraints: ConstraintManager by lazy { ConstraintManager(connectionProvider, indexes) }

--- a/src/main/kotlin/org/drivine/manager/PersistenceManager.kt
+++ b/src/main/kotlin/org/drivine/manager/PersistenceManager.kt
@@ -44,6 +44,22 @@ interface PersistenceManager {
     val constraints: ConstraintManager
 
     /**
+     * Whether [indexes] and [constraints] can actually do anything on this database.
+     *
+     * Some engines have no schema DDL — Neptune and generic openCypher resolve to
+     * [org.drivine.schema.UnsupportedSchemaGrammar], which throws on every operation by design.
+     * Callers that provision schema at startup need to know that BEFORE issuing DDL, and asking
+     * the engine's identity is the wrong question: it is the grammar that can or cannot, and an
+     * engine the caller has never heard of may be perfectly capable. Ask this instead of
+     * matching [type] against a set of known-good engines.
+     *
+     * Defaults to true so existing implementations keep compiling; an engine without schema
+     * management must say so.
+     */
+    val supportsSchemaManagement: Boolean
+        get() = true
+
+    /**
      * Queries for a set of results according to the supplied specification.
      * @param spec
      * TODO: Return Map type.

--- a/src/main/kotlin/org/drivine/manager/TransactionalPersistenceManager.kt
+++ b/src/main/kotlin/org/drivine/manager/TransactionalPersistenceManager.kt
@@ -27,6 +27,10 @@ class TransactionalPersistenceManager(
 
     private val finderOperations: FinderOperations = FinderOperations(this)
 
+    /** False when no schema source was supplied: nothing here could run DDL even if the engine could. */
+    override val supportsSchemaManagement: Boolean
+        get() = schemaManagerSource?.supportsSchemaManagement ?: false
+
     override val indexes: IndexManager
         get() = schemaManagerSource?.indexes ?: throw DrivineException(
             "Schema management is not available on this TransactionalPersistenceManager instance. " +

--- a/src/main/kotlin/org/drivine/schema/FalkorDbSchemaGrammar.kt
+++ b/src/main/kotlin/org/drivine/schema/FalkorDbSchemaGrammar.kt
@@ -24,6 +24,7 @@ class FalkorDbSchemaGrammar : SchemaGrammar {
     override fun unsupportedVectorTuning(spec: VectorIndexSpec): List<String> = emptyList()
     override val constraintsRequireBackingIndex = true
     override val constraintCreationIsAsync = true
+    override val indexOperationsAreAsync = true
 
     // ----- DDL emission -----
 

--- a/src/main/kotlin/org/drivine/schema/IndexManager.kt
+++ b/src/main/kotlin/org/drivine/schema/IndexManager.kt
@@ -1,7 +1,9 @@
 package org.drivine.schema
 
+import org.drivine.DrivineException
 import org.drivine.connection.ConnectionProvider
 import org.slf4j.LoggerFactory
+import java.time.Duration
 
 /**
  * Idempotent, drift-aware index management for a single database.
@@ -28,6 +30,8 @@ import org.slf4j.LoggerFactory
 class IndexManager internal constructor(
     private val executor: SchemaExecutor,
     val grammar: SchemaGrammar,
+    private val asyncDropTimeout: Duration = Duration.ofSeconds(30),
+    private val asyncPollInterval: Duration = Duration.ofMillis(200),
 ) {
 
     internal constructor(connectionProvider: ConnectionProvider) :
@@ -114,8 +118,7 @@ class IndexManager internal constructor(
      */
     fun drop(spec: IndexSpec): Boolean {
         val existing = find(spec) ?: return false
-        executor.execute(grammar.dropIndex(narrowTo(existing, spec)))
-        logger.info("Dropped {} {} on {}{}", grammar.engine, spec.kind, spec.label, spec.properties)
+        dropExisting(existing, spec)
         return true
     }
 
@@ -126,7 +129,7 @@ class IndexManager internal constructor(
     fun recreate(spec: IndexSpec): EnsureResult.Recreated {
         val existing = find(spec)
         if (existing != null) {
-            executor.execute(grammar.dropIndex(narrowTo(existing, spec)))
+            dropExisting(existing, spec)
         }
         // Re-introspect after the drop: on per-label-index engines the label may still have an
         // index covering other properties, which creation must take into account
@@ -178,6 +181,33 @@ class IndexManager internal constructor(
             "Vector index {} on {}{} effective config ({}): {}",
             created.name ?: spec.effectiveName, spec.label, spec.properties, pinned, effective
         )
+    }
+
+    /**
+     * Drops [existing], narrowed to what [spec] asked for, and — on engines that tear indexes down
+     * in the background (FalkorDB) — waits until the index is actually gone. Without the wait the
+     * DDL returns while introspection still reports the index, so a caller that drops and then
+     * looks (or recreates) sees the index it just removed.
+     */
+    private fun dropExisting(existing: SchemaItemInfo, spec: IndexSpec) {
+        executor.execute(grammar.dropIndex(narrowTo(existing, spec)))
+        awaitDropped(spec)
+        logger.info("Dropped {} {} on {}{}", grammar.engine, spec.kind, spec.label, spec.properties)
+    }
+
+    /** Polls until [spec] no longer resolves to an index, on engines whose drops are asynchronous. */
+    private fun awaitDropped(spec: IndexSpec) {
+        if (!grammar.indexOperationsAreAsync) return
+        val deadline = System.currentTimeMillis() + asyncDropTimeout.toMillis()
+        while (find(spec) != null) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw DrivineException(
+                    "Timed out after $asyncDropTimeout waiting for ${spec.kind} on " +
+                        "${spec.label}${spec.properties} to be dropped"
+                )
+            }
+            Thread.sleep(asyncPollInterval.toMillis())
+        }
     }
 
     /**

--- a/src/main/kotlin/org/drivine/schema/SchemaGrammar.kt
+++ b/src/main/kotlin/org/drivine/schema/SchemaGrammar.kt
@@ -45,6 +45,14 @@ interface SchemaGrammar {
     val constraintCreationIsAsync: Boolean
         get() = false
 
+    /**
+     * Whether index creation and dropping are asynchronous — the DDL returns immediately while the
+     * engine builds or tears the index down in the background, so introspection can still report an
+     * index that has just been dropped (FalkorDB).
+     */
+    val indexOperationsAreAsync: Boolean
+        get() = false
+
     // ----- DDL emission -----
 
     /**

--- a/src/test/kotlin/org/drivine/manager/SchemaCapabilityTest.kt
+++ b/src/test/kotlin/org/drivine/manager/SchemaCapabilityTest.kt
@@ -1,0 +1,73 @@
+package org.drivine.manager
+
+import org.assertj.core.api.Assertions.assertThat
+import org.drivine.connection.Connection
+import org.drivine.connection.ConnectionProvider
+import org.drivine.connection.DataSourceMap
+import org.drivine.connection.DatabaseRegistry
+import org.drivine.connection.DatabaseType
+import org.drivine.query.QuerySpecification
+import org.drivine.query.grammar.CypherDialect
+import org.drivine.transaction.TransactionContextHolder
+import org.junit.jupiter.api.Test
+
+/**
+ * Schema capability is a property of the engine's grammar, and callers that provision at startup
+ * need it before issuing DDL. It was reachable only from [ConnectionProvider]; the managers are
+ * what those callers actually hold, so it has to be answerable there — otherwise they resort to
+ * matching [DatabaseType] against a set of engines they happen to know, which is wrong the moment
+ * a new one appears.
+ */
+class SchemaCapabilityTest {
+
+    private class StandInConnection : Connection {
+        override fun sessionId(): String = "stand-in"
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> query(spec: QuerySpecification<T>): List<T> = emptyList<Any>() as List<T>
+        override fun startTransaction() = Unit
+        override fun commitTransaction() = Unit
+        override fun rollbackTransaction() = Unit
+        override fun release(error: Throwable?) = Unit
+    }
+
+    private class StandInProvider(
+        override val name: String,
+        override val cypherDialect: CypherDialect,
+    ) : ConnectionProvider {
+        override val type: DatabaseType = DatabaseType.EMBABEL
+        override val subtypeRegistry = null
+        override fun connect(): Connection = StandInConnection()
+        override fun end() = Unit
+    }
+
+    private fun managerFor(dialect: CypherDialect): PersistenceManager {
+        val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
+        registry.register(StandInProvider("graph", dialect))
+        return PersistenceManagerFactory(registry, TransactionContextHolder(registry)).get("graph")
+    }
+
+    @Test
+    fun `an engine whose grammar has schema DDL says so through the manager`() {
+        assertThat(managerFor(CypherDialect.NEO4J_5).supportsSchemaManagement).isTrue
+    }
+
+    @Test
+    fun `an engine with no schema DDL says so too, rather than being guessed at by type`() {
+        /* OPEN_CYPHER resolves to UnsupportedSchemaGrammar, which throws on every operation */
+        assertThat(managerFor(CypherDialect.OPEN_CYPHER).supportsSchemaManagement).isFalse
+    }
+
+    @Test
+    fun `a transactional manager with no schema source cannot run DDL and admits it`() {
+        val registry = DatabaseRegistry(DataSourceMap(mutableMapOf()))
+        registry.register(StandInProvider("graph", CypherDialect.NEO4J_5))
+        val orphan = TransactionalPersistenceManager(
+            TransactionContextHolder(registry),
+            "graph",
+            DatabaseType.EMBABEL,
+            registry.subtypeRegistry,
+            CypherDialect.NEO4J_5.grammar(),
+        )
+        assertThat(orphan.supportsSchemaManagement).isFalse
+    }
+}


### PR DESCRIPTION
## BLUF

Schema capability is reachable only from `ConnectionProvider`, but the callers that provision schema at startup hold a `PersistenceManager`. With no way to ask, they guess from `DatabaseType` — and a guess spelled as a set of known-good engines fails closed on every engine added afterwards.

`PersistenceManager.supportsSchemaManagement` answers the question where it is actually asked. Additive, defaulted, 816 tests green.

---

## Code Before

Downstream, in `embabel-agent-rag-graph`'s `EntitySchemaProvisioner`:

```kotlin
private val SCHEMA_CAPABLE = setOf(DatabaseType.NEO4J, DatabaseType.MEMGRAPH, DatabaseType.FALKORDB)

init {
    if (enabled && persistenceManager.type !in SCHEMA_CAPABLE) {
        throw DrivineException(
            "${persistenceManager.type} has no schema management, so the entity indexes " +
                "'${properties.entityIndex}' and '${properties.entityFullTextIndex}' that entity " +
                "search binds by name cannot be created. Supported engines: " + ...
```

Its own doc comment states the rule it means:

> *"An engine with no schema management at all (Neptune, Postgres — Drivine's `UnsupportedSchemaGrammar` throws on every call, deliberately) can never succeed, so it is refused at construction rather than retried on every search forever."*

That is exactly right, and it is a property of the **grammar**, not the engine's name. Written as an allowlist it rejects an engine that resolves `Neo4jSchemaGrammar` and can create every index asked of it, purely because the set predates it.

## Code Now

```kotlin
/**
 * Whether [indexes] and [constraints] can actually do anything on this database.
 * ... asking the engine's identity is the wrong question: it is the grammar that can or
 * cannot, and an engine the caller has never heard of may be perfectly capable.
 */
val supportsSchemaManagement: Boolean
    get() = true
```

It routes the way `indexes` and `constraints` already do:

```kotlin
// NonTransactional — asks its provider
override val supportsSchemaManagement get() = connectionProvider.supportsSchemaManagement

// Delegating — schema always routes to the non-transactional manager
override val supportsSchemaManagement
    get() = factory.get(database, NON_TRANSACTIONAL).supportsSchemaManagement

// Transactional — false when no schema source was supplied: nothing here could run DDL
override val supportsSchemaManagement get() = schemaManagerSource?.supportsSchemaManagement ?: false
```

So the downstream check becomes `if (enabled && !persistenceManager.supportsSchemaManagement)`, with the same message and the same fail-at-construction behaviour — minus the allowlist.

## Compatibility

Defaulted to `true` on the interface, so existing `PersistenceManager` implementations keep compiling. An engine without schema DDL overrides it; the three built-in managers all do. Purely additive — no signature changes, no removals.

## Tests

`SchemaCapabilityTest`: an engine whose dialect resolves `Neo4jSchemaGrammar` reports true; one resolving `UnsupportedSchemaGrammar` reports false (rather than being guessed at by type); and a transactional manager built without a schema source reports false.

816 tests pass.

## Why now

`DatabaseType.EMBABEL` (0.0.80) is exactly the engine the allowlist rejects: its provider declares `NEO4J_5`, so `schemaGrammar()` is `Neo4jSchemaGrammar` and it creates indexes and constraints perfectly well — but `EMBABEL !in SCHEMA_CAPABLE`, so entity search refuses to construct. This is the last thing keeping a hand-written repository twin alive in the assistant (embabel/me#1084 and its follow-ups).

Wants a 0.0.81 to be usable downstream.
